### PR TITLE
Explicit -loader suffix

### DIFF
--- a/packages/babel6/CHANGELOG.md
+++ b/packages/babel6/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @webpack-blocks/babel6 - Changelog
+
+## 0.1.1
+
+- `loaders: [ 'babel' ]` => `loaders: [ 'babel-loader' ]`
+
+## 0.1.0
+
+Initial release.

--- a/packages/babel6/index.js
+++ b/packages/babel6/index.js
@@ -21,7 +21,7 @@ function babel (options) {
         {
           test: fileTypes('application/javascript'),
           exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-          loaders: [ 'babel?cacheDirectory' ]
+          loaders: [ 'babel-loader?cacheDirectory' ]
         }
       ]
     }

--- a/packages/babel6/package.json
+++ b/packages/babel6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/babel6",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Webpack block for babel 6+.",
   "main": "lib/index",
   "license": "MIT",

--- a/packages/css-modules/CHANGELOG.md
+++ b/packages/css-modules/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @webpack-blocks/css-modules - Changelog
+
+## 0.1.1
+
+- `loaders: [ 'style', 'css' ]` => `loaders: [ 'style-loader', 'css-loader' ]`
+
+## 0.1.0
+
+Initial release.

--- a/packages/css-modules/index.js
+++ b/packages/css-modules/index.js
@@ -30,7 +30,7 @@ function cssModules (options) {
         {
           test: fileTypes('text/css'),
           exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-          loaders: [ 'style', 'css?' + stringifyQueryParams({ importLoaders, localIdentName, modules: true }) ]
+          loaders: [ 'style-loader', 'css-loader?' + stringifyQueryParams({ importLoaders, localIdentName, modules: true }) ]
         }
       ]
     }

--- a/packages/css-modules/package.json
+++ b/packages/css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/css-modules",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Webpack block for CSS modules.",
   "main": "lib/index",
   "license": "MIT",

--- a/packages/postcss/CHANGELOG.md
+++ b/packages/postcss/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @webpack-blocks/postcss - Changelog
+
+## 0.1.1
+
+- `loaders: [ 'postcss' ]` => `loaders: [ 'postcss-loader' ]`
+
+## 0.1.0
+
+Initial release.

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -22,7 +22,7 @@ function postcss (plugins, options) {
         {
           test: fileTypes('text/css'),
           exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-          loaders: [ 'postcss' ]
+          loaders: [ 'postcss-loader' ]
         }
       ]
     },

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/postcss",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Webpack block for PostCSS.",
   "main": "lib/index",
   "license": "MIT",

--- a/packages/sass/CHANGELOG.md
+++ b/packages/sass/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @webpack-blocks/sass - Changelog
+
+## 0.1.1
+
+- `loaders: [ 'style', 'css', 'sass' ]` => `loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]`
+
+## 0.1.0
+
+Initial release.

--- a/packages/sass/index.js
+++ b/packages/sass/index.js
@@ -15,7 +15,7 @@ function sass () {
       loaders: [
         {
           test: fileTypes('text/x-sass'),
-          loaders: [ 'style', 'css', 'sass' ]
+          loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]
         }
       ]
     }

--- a/packages/sass/package.json
+++ b/packages/sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/sass",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Webpack block for SASS.",
   "main": "lib/index",
   "license": "MIT",

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/webpack - Changelog
 
+## 0.1.4
+
+- Use explicit `-loader` suffix
+
 ## 0.1.3
 
 - Bugfix: `context` and `output.path` paths are now absolute as they are supposed to be

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.4
 
 - Use explicit `-loader` suffix
+- Remove empty string from `resolve.extensions`
 
 ## 0.1.3
 

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -76,6 +76,8 @@ test('complete webpack config creation', (t) => {
 
   t.is(webpackConfig.devtool, 'cheap-module-source-map')
 
+  t.deepEqual(webpackConfig.resolve.extensions.sort(), [ '.js', '.json', '.jsx' ])
+
   t.deepEqual(Object.keys(webpackConfig).sort(), [
     'devServer', 'devtool', 'entry', 'module', 'output', 'plugins', 'resolve'
   ])

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -25,37 +25,37 @@ test('complete webpack config creation', (t) => {
   t.is(webpackConfig.module.loaders.length, 8)
   t.deepEqual(webpackConfig.module.loaders[0], {
     test: /\.(sass|scss)$/,
-    loaders: [ 'style', 'css', 'sass' ]
+    loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]
   })
   t.deepEqual(webpackConfig.module.loaders[1], {
     test: /\.css$/,
     exclude: [ /\/node_modules\// ],
-    loaders: [ 'style', 'css?importLoaders=1&localIdentName=[name]--[local]--[hash:base64:5]&modules' ]
+    loaders: [ 'style-loader', 'css-loader?importLoaders=1&localIdentName=[name]--[local]--[hash:base64:5]&modules' ]
   })
   t.deepEqual(webpackConfig.module.loaders[2], {
     test: /\.(js|jsx)$/,
     exclude: [ /\/node_modules\// ],
-    loaders: [ 'babel?cacheDirectory' ]
+    loaders: [ 'babel-loader?cacheDirectory' ]
   })
   t.deepEqual(webpackConfig.module.loaders[3], {
     test: /\.(gif|ico|jpg|jpeg|png|svg|webp)$/,
-    loaders: [ 'file' ]
+    loaders: [ 'file-loader' ]
   })
   t.deepEqual(webpackConfig.module.loaders[4], {
     test: /\.(eot|ttf|woff|woff2)(\?.*)?$/,
-    loaders: [ 'file' ]
+    loaders: [ 'file-loader' ]
   })
   t.deepEqual(webpackConfig.module.loaders[5], {
     test: /\.json$/,
-    loaders: [ 'json' ]
+    loaders: [ 'json-loader' ]
   })
   t.deepEqual(webpackConfig.module.loaders[6], {
     test: /\.(aac|m4a|mp3|oga|ogg|wav)$/,
-    loaders: [ 'url' ]
+    loaders: [ 'url-loader' ]
   })
   t.deepEqual(webpackConfig.module.loaders[7], {
     test: /\.(mp4|webm)$/,
-    loaders: [ 'url' ]
+    loaders: [ 'url-loader' ]
   })
 
   t.deepEqual(webpackConfig.entry, [ './src/main.js', 'webpack/hot/only-dev-server' ])

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -39,22 +39,22 @@ function createBaseConfig (fileTypes) {
         {
           test: fileTypes('text/css'),
           exclude: [ /\/node_modules\// ],
-          loaders: [ 'style', 'css' ]
+          loaders: [ 'style-loader', 'css-loader' ]
         }, {
           test: fileTypes('image'),
-          loaders: [ 'file' ]
+          loaders: [ 'file-loader' ]
         }, {
           test: fileTypes('application/font'),
-          loaders: [ 'file' ]
+          loaders: [ 'file-loader' ]
         }, {
           test: fileTypes('application/json'),
-          loaders: [ 'json' ]
+          loaders: [ 'json-loader' ]
         }, {
           test: fileTypes('audio'),
-          loaders: [ 'url' ]
+          loaders: [ 'url-loader' ]
         }, {
           test: fileTypes('video'),
-          loaders: [ 'url' ]
+          loaders: [ 'url-loader' ]
         }
       ]
     },

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -60,7 +60,7 @@ function createBaseConfig (fileTypes) {
     },
 
     resolve: {
-      extensions: [ '.js', '.jsx', '.json', '' ]
+      extensions: [ '.js', '.jsx', '.json' ]
     }
   }
 }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/webpack",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Webpack block for the webpack 1.x base configuration.",
   "license": "MIT",
   "author": "Andy Wermke <andy@dev.next-step-software.com>",


### PR DESCRIPTION
Use explicit `-loader` suffix on loaders, since webpack 2 is going to enforce this convention.
Also removed empty string from `resolve.extensions`.