### PR TITLE
Add empty extension to the default extensions

### DIFF
--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -76,7 +76,7 @@ test('complete webpack config creation', (t) => {
 
   t.is(webpackConfig.devtool, 'cheap-module-source-map')
 
-  t.deepEqual(webpackConfig.resolve.extensions.sort(), [ '.js', '.json', '.jsx' ])
+  t.deepEqual(webpackConfig.resolve.extensions.sort(), [ '', '.js', '.json', '.jsx' ])
 
   t.deepEqual(Object.keys(webpackConfig).sort(), [
     'devServer', 'devtool', 'entry', 'module', 'output', 'plugins', 'resolve'

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -60,7 +60,7 @@ function createBaseConfig (fileTypes) {
     },
 
     resolve: {
-      extensions: [ '.js', '.jsx', '.json' ]
+      extensions: [ '', '.js', '.jsx', '.json' ]
     }
   }
 }


### PR DESCRIPTION
When trying to use a file including the extension, it will crash unless you have an empty extension. It is a pretty common Webpack configuration.

Before the fix this configuration was throwing an error: 

```js
const path = require('path');
const { createConfig, entryPoint, env, setOutput, webpack } = require('@webpack-blocks/webpack');
const babel = require('@webpack-blocks/babel6');

const config = createConfig([
  entryPoint('./src/index.js'),
  setOutput('./build/bundle.js'),
  babel(),
]);

module.exports = config;
```

**ERROR in multi main
Module not found: Error: Cannot resolve 'file' or 'directory' ./test.js in /private/var/git/thereactivestack/webpack-blocks-test/src
 @ multi main**


But it was working if I was using `./src/index` instead without the extension.