### PR TITLE
Fix dev-server when using named entries

### DIFF
--- a/packages/core/src/__tests__/entryPoint.test.js
+++ b/packages/core/src/__tests__/entryPoint.test.js
@@ -1,0 +1,23 @@
+import test from 'ava'
+import { entryPoint } from '../index'
+
+test('entryPoint() should normalize string to object entry', (t) => {
+  let config = {}
+
+  config = entryPoint('./test.js')(null, config)
+  t.deepEqual(config.entry.main, { main: ['./test.js'] })
+})
+
+test('entryPoint() should normalize array to object entry', (t) => {
+  let config = {}
+
+  config = entryPoint(['./test.js'])(null, config)
+  t.deepEqual(config.entry.main, { main: ['./test.js'] })
+})
+
+test('entryPoint() should keep intact object entry', (t) => {
+  let config = {}
+
+  config = entryPoint({ main: './test.js' })(null, config)
+  t.deepEqual(config.entry.main, { main: ['./test.js'] })
+})

--- a/packages/dev-server/__tests__/devServer.test.js
+++ b/packages/dev-server/__tests__/devServer.test.js
@@ -1,0 +1,25 @@
+import test from 'ava'
+import devServer from '../index'
+
+test('devServer() add himself to every entries', (t) => {
+  let config = {
+    entry: {
+      main: ['./test.js'],
+      second: ['./second.js']
+    }
+  }
+
+  config = devServer('entry')(null, config)
+  t.deepEqual(config.entry, { main: ['entry'], second: ['entry'] })
+})
+
+test('devServer() use webpack/hot/only-dev-server as default', (t) => {
+  let config = {
+    entry: {
+      main: ['./test.js']
+    }
+  }
+
+  config = devServer()(null, config)
+  t.deepEqual(config.entry.main, ['webpack/hot/only-dev-server'])
+})

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -40,39 +40,39 @@ function devServer (options, entry) {
   })
 }
 
-function addDevEntry(devServerEntry, config) {
+function addDevEntry (devServerEntry, config) {
   if (typeof devServerEntry === 'string') {
-    devServerEntry = [devServerEntry];
+    devServerEntry = [devServerEntry]
   }
 
   if (!config.entry) {
-    config.entry = [];
+    config.entry = []
   } else if (typeof config.entry === 'string') {
-    config.entry = [config.entry];
+    config.entry = [config.entry]
   }
 
   if (typeof config.entry === 'object') {
     if (Array.isArray(config.entry)) {
-      return devServerEntry.concat(config.entry);
+      return devServerEntry.concat(config.entry)
     } else {
-      var entry = {};
+      var entry = {}
 
       // Adding dev server to all entries
       for (let chunkName in config.entry) {
-        var chunkEntry = config.entry[chunkName];
+        var chunkEntry = config.entry[chunkName]
 
         if (typeof chunkEntry === 'string') {
-          chunkEntry = [chunkEntry];
+          chunkEntry = [chunkEntry]
         }
 
-        entry[chunkName] = devServerEntry.concat(chunkEntry);
+        entry[chunkName] = devServerEntry.concat(chunkEntry)
       }
 
-      return entry;
+      return entry
     }
   }
 
-  return devServerEntry;
+  return devServerEntry
 }
 
 /**

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -45,27 +45,28 @@ function addDevEntry (devServerEntry, config) {
     devServerEntry = [devServerEntry]
   }
 
-  if (!config.entry) {
-    config.entry = []
-  } else if (typeof config.entry === 'string') {
-    config.entry = [config.entry]
+  var configEntry = config.entry
+  if (!configEntry) {
+    configEntry = []
+  } else if (typeof configEntry === 'string') {
+    configEntry = [configEntry]
   }
 
-  if (typeof config.entry === 'object') {
-    if (Array.isArray(config.entry)) {
-      return devServerEntry.concat(config.entry)
+  if (typeof configEntry === 'object') {
+    if (Array.isArray(configEntry)) {
+      return devServerEntry
     } else {
       var entry = {}
 
-      // Adding dev server to all entries
-      for (let chunkName in config.entry) {
-        var chunkEntry = config.entry[chunkName]
+      // Merging has to be done manually when using multiple entry points
+      for (let chunkName in configEntry) {
+        var chunkEntry = configEntry[chunkName]
 
         if (typeof chunkEntry === 'string') {
           chunkEntry = [chunkEntry]
         }
 
-        entry[chunkName] = devServerEntry.concat(chunkEntry)
+        entry[chunkName] = chunkEntry.concat(devServerEntry)
       }
 
       return entry

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -27,17 +27,52 @@ function devServer (options, entry) {
     entry = entry || 'webpack/hot/only-dev-server'
   }
 
-  return (fileTypes) => ({
+  return (fileTypes, config) => ({
     devServer: Object.assign({
       hot: true,
       historyApiFallback: true,
       inline: true
     }, options),
-    entry: Array.isArray(entry) ? entry : [ entry ],
+    entry: addDevEntry(entry, config),
     plugins: [
       new webpack.HotModuleReplacementPlugin()
     ]
   })
+}
+
+function addDevEntry(devServerEntry, config) {
+  if (typeof devServerEntry === 'string') {
+    devServerEntry = [devServerEntry];
+  }
+
+  if (!config.entry) {
+    config.entry = [];
+  } else if (typeof config.entry === 'string') {
+    config.entry = [config.entry];
+  }
+
+  if (typeof config.entry === 'object') {
+    if (Array.isArray(config.entry)) {
+      return devServerEntry.concat(config.entry);
+    } else {
+      var entry = {};
+
+      // Adding dev server to all entries
+      for (let chunkName in config.entry) {
+        var chunkEntry = config.entry[chunkName];
+
+        if (typeof chunkEntry === 'string') {
+          chunkEntry = [chunkEntry];
+        }
+
+        entry[chunkName] = devServerEntry.concat(chunkEntry);
+      }
+
+      return entry;
+    }
+  }
+
+  return devServerEntry;
 }
 
 /**

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -41,39 +41,18 @@ function devServer (options, entry) {
 }
 
 function addDevEntry (devServerEntry, config) {
-  if (typeof devServerEntry === 'string') {
+  if (!Array.isArray(devServerEntry)) {
     devServerEntry = [devServerEntry]
   }
 
-  var configEntry = config.entry
-  if (!configEntry) {
-    configEntry = []
-  } else if (typeof configEntry === 'string') {
-    configEntry = [configEntry]
+  var entry = {}
+
+  // We need dev-server on every entry
+  for (var chunkName in config.entry) {
+    entry[chunkName] = devServerEntry
   }
 
-  if (typeof configEntry === 'object') {
-    if (Array.isArray(configEntry)) {
-      return devServerEntry
-    } else {
-      var entry = {}
-
-      // Merging has to be done manually when using multiple entry points
-      for (let chunkName in configEntry) {
-        var chunkEntry = configEntry[chunkName]
-
-        if (typeof chunkEntry === 'string') {
-          chunkEntry = [chunkEntry]
-        }
-
-        entry[chunkName] = chunkEntry.concat(devServerEntry)
-      }
-
-      return entry
-    }
-  }
-
-  return devServerEntry
+  return entry
 }
 
 /**

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Andy Wermke <andy@dev.next-step-software.com>",
   "scripts": {
-    "test": "standard",
+    "test": "standard && ava",
     "prepublish": "npm test"
   },
   "engines": {
@@ -19,6 +19,7 @@
     "webpack-dev-server": "^1.16.2"
   },
   "devDependencies": {
+    "ava": "^0.16.0",
     "standard": "^8.1.0"
   }
 }

--- a/packages/webpack/__tests__/entryPoint.test.js
+++ b/packages/webpack/__tests__/entryPoint.test.js
@@ -1,0 +1,9 @@
+import test from 'ava'
+import { entryPoint } from '../index'
+
+test('entryPoint() should normalize string to object entry', (t) => {
+  let config = {}
+
+  config = entryPoint('./test.js')(null, config)
+  t.deepEqual(config.entry, { main: ['./test.js'] })
+})

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -58,7 +58,7 @@ test('complete webpack config creation', (t) => {
     loaders: [ 'url-loader' ]
   })
 
-  t.deepEqual(webpackConfig.entry, [ './src/main.js', 'webpack/hot/only-dev-server' ])
+  t.deepEqual(webpackConfig.entry, { main: [ './src/main.js', 'webpack/hot/only-dev-server' ] })
 
   t.deepEqual(webpackConfig.devServer, {
     hot: true,

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -70,8 +70,25 @@ function createBaseConfig (fileTypes) {
  */
 function entryPoint (entry) {
   return () => ({
-    entry: typeof entry === 'string' ? [ entry ] : entry
+    entry: normalizeEntry(entry)
   })
+}
+
+function normalizeEntry (entry) {
+  if (typeof entry === 'object') {
+    if (Array.isArray(entry)) {
+      return { main: entry }
+    } else {
+      Object.keys(entry).forEach(function normalizeNamedEntry (entryName) {
+        if (!Array.isArray(entry[entryName])) {
+          entry[entryName] = [entry[entryName]]
+        }
+      })
+      return entry
+    }
+  }
+
+  return { main: [entry] }
 }
 
 /**


### PR DESCRIPTION
When adding `devServer` on an entry like that: `entryPoint({ app: './src/index' })`, it would override the whole entry point by only the devServer.

This is fixing the way the entry is merged. 

Here is my whole webpack.config.js:

```js
const path = require('path');
const { createConfig, env, entryPoint, setOutput, addPlugins, setDevTool, webpack } = require('@webpack-blocks/webpack');
const babel = require('@webpack-blocks/babel6');
const cssModules = require('@webpack-blocks/css-modules');
const extractText = require('@webpack-blocks/extract-text');
const { StatsWriterPlugin } = require('webpack-stats-plugin');
const devServer = require('@webpack-blocks/dev-server');

const development = [
  setOutput({ filename: '[name].js' }),
  setDevTool('eval'),
  addPlugins([
    new webpack.DefinePlugin({ __DEV__: JSON.stringify(true) }),
    new webpack.NoErrorsPlugin(),
  ]),
  devServer('webpack-hot-middleware/client'),
  devServer.reactHot(),
];

const production = [
  setDevTool('source-map'),
  addPlugins([
    new webpack.DefinePlugin({ __DEV__: JSON.stringify(false) }),
    new webpack.optimize.DedupePlugin(),
    new webpack.optimize.CommonsChunkPlugin({
      name: 'vendor',
      minChunks(module) { return /node_modules/.test(module); }
    }),
    new webpack.optimize.UglifyJsPlugin({
      compress: { warnings: true },
      screwIe8: true
    }),
  ]),
  extractText('style.[contenthash].css'),
];

module.exports = createConfig([
  entryPoint({ app: './src/index' }),
  setOutput({
    path: path.resolve('./build'),
    filename: '[name].[hash].js',
    publicPath: '/assets/'
  }),
  babel(),
  cssModules(),
  addPlugins([
    new StatsWriterPlugin({ fields: ['publicPath', 'assetsByChunkName'] }),
    new webpack.DefinePlugin({ 'process.env': JSON.stringify(process.env), }),
    new webpack.DefinePlugin({
      __CLIENT__: JSON.stringify(true),
      __SERVER__: JSON.stringify(false),
    }),
    new webpack.optimize.OccurrenceOrderPlugin(),
  ]),
  env('development', development),
  env('production', production),
]);
```