### PR TITLE
Bugfix: Fix extract-text block

### DIFF
--- a/packages/extract-text/CHANGELOG.md
+++ b/packages/extract-text/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @webpack-blocks/extract-text - Changelog
+
+## 0.1.1
+
+- Fixed ExtractTextPlugin usage (failed before if > 2 webpack loaders were assigned to the file type)
+- Added a parameter to use ExtractTextPlugin on different file types as CSS (SASS, for instance)
+
+## 0.1.0
+
+Initial release.

--- a/packages/extract-text/README.md
+++ b/packages/extract-text/README.md
@@ -14,7 +14,9 @@ const extractText = require('@webpack-blocks/extract-text')
 
 module.exports = createConfig([
   ...,
-  extractText('css/[name].css')   // or just `extractText()`
+  extractText(),
+  // or:
+  extractText('css/[name].css', 'text/css')
 ])
 ```
 

--- a/packages/extract-text/index.js
+++ b/packages/extract-text/index.js
@@ -9,26 +9,39 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
 module.exports = extractText
 
 /**
- * @param {string}    outputFilePattern
+ * @param {string}  outputFilePattern
+ * @param {string}  [fileType]          A MIME type used for file matching. Defaults to `text/css`.
  * @return {Function}
  */
-function extractText (outputFilePattern) {
+function extractText (outputFilePattern, fileType) {
   outputFilePattern = outputFilePattern || 'css/[name].[contenthash:8].css'
+  fileType = fileType || 'text/css'
 
   return (fileTypes, webpackConfig) => {
-    const cssLoader = webpackConfig.module.loaders.find((loader) => loader.test === fileTypes('text/css'))
+    const cssLoader = webpackConfig.module.loaders.find((loader) => loader.test === fileTypes(fileType))
 
     if (!cssLoader) {
-      throw new Error(`CSS loader could not be found in webpack config.`)
+      throw new Error(`${fileType} loader could not be found in webpack config.`)
     }
+
+    if (!cssLoader.loaders || cssLoader.loaders.length === 0) {
+      throw new Error(`No ${fileType} file loaders found.`)
+    }
+    if (!/^style(-loader)?$/.test(cssLoader.loaders[0])) {
+      throw new Error(`Expected "style-loader" to be first loader of .css files. Instead got: ${cssLoader.loaders[0]}`)
+    }
+
+    // `cssLoader.loaders` without the leading 'style-loader'
+    const nonStyleLoaders = [].concat(cssLoader.loaders)
+    nonStyleLoaders.shift()
 
     return {
       module: {
         loaders: [
           {
-            test: fileTypes('text/css'),
+            test: fileTypes(fileType),
             exclude: cssLoader.exclude,
-            loader: ExtractTextPlugin.extract.apply(null, cssLoader.loaders),
+            loader: ExtractTextPlugin.extract('style-loader', nonStyleLoaders),
             loaders: undefined
           }
         ]

--- a/packages/extract-text/package.json
+++ b/packages/extract-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/extract-text",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Webpack block for the Extract-text plugin.",
   "main": "lib/index",
   "license": "MIT",


### PR DESCRIPTION
Didn't work before when there were more than 2 webpack loaders assigned to a file type.

Also added another parameter, so you can now apply the ExtractTextPlugin on other file types as CSS (like SASS, for instance) as well.