### PR TITLE
Implement `defineConstants`

### DIFF
--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -41,6 +41,12 @@ Takes an array of config setters (the functions returned by invoked webpack bloc
 
 Combines an array of blocks to a new joined block. Running this single block has the same effect as running all source blocks.
 
+#### defineConstants(constants: object): Function
+
+Replaces constants in your source code with a value (`process.env.NODE_ENV` for example) using the [webpack.DefinePlugin](https://webpack.github.io/docs/list-of-plugins.html#defineplugin). Pass an object containing your constant definitions: `{ [constantName: string]: <constantValue: any> }`.
+
+Special feature: Using `defineConstants` multiple times results in a single DefinePlugin instance configured to do all the replacements.
+
 #### env(envName: string, configSetters: Function[]): Function
 
 Applies an array of webpack blocks only if `process.env.NODE_ENV` matches the given `envName`. If no `NODE_ENV` is set, it will be treated as 'development'.

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -45,6 +45,8 @@ Combines an array of blocks to a new joined block. Running this single block has
 
 Replaces constants in your source code with a value (`process.env.NODE_ENV` for example) using the [webpack.DefinePlugin](https://webpack.github.io/docs/list-of-plugins.html#defineplugin). Pass an object containing your constant definitions: `{ [constantName: string]: <constantValue: any> }`.
 
+Every constant's value is `JSON.stringify()`-ed first, so you don't have to remember.
+
 Special feature: Using `defineConstants` multiple times results in a single DefinePlugin instance configured to do all the replacements.
 
 #### env(envName: string, configSetters: Function[]): Function

--- a/packages/webpack/__e2e-fixtures__/babel-postcss-extract-text/webpack.config.js
+++ b/packages/webpack/__e2e-fixtures__/babel-postcss-extract-text/webpack.config.js
@@ -1,11 +1,10 @@
 const webpackBlock = require('../../index')
 
 // Need to write it like this instead of destructuring so it runs on Node 4.x w/o transpiling
-const addPlugins = webpackBlock.addPlugins
 const createConfig = webpackBlock.createConfig
+const defineConstants = webpackBlock.defineConstants
 const entryPoint = webpackBlock.entryPoint
 const setOutput = webpackBlock.setOutput
-const webpack = webpackBlock.webpack
 
 const babel = require('@webpack-blocks/babel6')
 const postcss = require('@webpack-blocks/postcss')
@@ -27,9 +26,7 @@ module.exports = createConfig([
   extractText(
     path.join('styles.css')
   ),
-  addPlugins([
-    new webpack.DefinePlugin({
-      'process.env': { TEST: '"This is the injected process.env.TEST!"' }
-    })
-  ])
+  defineConstants({
+    'process.env': { TEST: '"This is the injected process.env.TEST!"' }
+  })
 ])

--- a/packages/webpack/__e2e-fixtures__/babel-postcss-extract-text/webpack.config.js
+++ b/packages/webpack/__e2e-fixtures__/babel-postcss-extract-text/webpack.config.js
@@ -27,6 +27,6 @@ module.exports = createConfig([
     path.join('styles.css')
   ),
   defineConstants({
-    'process.env': { TEST: '"This is the injected process.env.TEST!"' }
+    'process.env.TEST': 'This is the injected process.env.TEST!'
   })
 ])

--- a/packages/webpack/__tests__/defineConstants.test.js
+++ b/packages/webpack/__tests__/defineConstants.test.js
@@ -1,0 +1,16 @@
+import test from 'ava'
+import { createConfig } from '@webpack-blocks/core'
+import { defineConstants } from '../index'
+
+test('defineConstants() creates a single DefinePlugin instance only', (t) => {
+  const config = createConfig([
+    defineConstants({ a: 'a' }),
+    defineConstants({ b: 'b' })
+  ])
+
+  t.is(Object.keys(config.plugins).length, 1)
+  t.deepEqual(config.plugins[0].definitions, {
+    a: 'a',
+    b: 'b'
+  })
+})

--- a/packages/webpack/__tests__/defineConstants.test.js
+++ b/packages/webpack/__tests__/defineConstants.test.js
@@ -9,8 +9,22 @@ test('defineConstants() creates a single DefinePlugin instance only', (t) => {
   ])
 
   t.is(Object.keys(config.plugins).length, 1)
+  t.deepEqual(Object.keys(config.plugins[0].definitions), [ 'a', 'b' ])
+})
+
+test('defineConstants() encodes the values', (t) => {
+  const config = createConfig([
+    defineConstants({
+      foo: 'foo',
+      bar: {
+        baz: 3
+      }
+    })
+  ])
+
+  t.is(Object.keys(config.plugins).length, 1)
   t.deepEqual(config.plugins[0].definitions, {
-    a: 'a',
-    b: 'b'
+    foo: '"foo"',
+    bar: '{\n  "baz": 3\n}'
   })
 })

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -15,6 +15,7 @@ exports.webpack = webpack
 exports.addPlugins = addPlugins
 exports.createConfig = createConfig
 exports.customConfig = customConfig
+exports.defineConstants = defineConstants
 exports.entryPoint = entryPoint
 exports.resolveAliases = resolveAliases
 exports.setContext = setContext
@@ -165,4 +166,29 @@ function setOutput (output) {
  */
 function sourceMaps (devtool) {
   return setDevTool(devtool || 'cheap-module-source-map')
+}
+
+/**
+ * Replaces constants in your source code with a value (`process.env.NODE_ENV`
+ * for example) using the `webpack.DefinePlugin`.
+ *
+ * Special feature: Using `defineConstants` multiple times results in a single
+ * DefinePlugin instance configured to do all the replacements.
+ *
+ * @param {object} constants  { [constantName: string]: * }
+ * @return {Function}
+ */
+function defineConstants (constants) {
+  return Object.assign((context) => {
+    context.defineConstants = Object.assign({}, context.defineConstants, constants)
+    return {}       // return empty webpack config snippet
+  }, { post: postDefineConstants })
+}
+
+function postDefineConstants (context) {
+  return {
+    plugins: [
+      new webpack.DefinePlugin(context.defineConstants)
+    ]
+  }
 }

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -170,7 +170,8 @@ function sourceMaps (devtool) {
 
 /**
  * Replaces constants in your source code with a value (`process.env.NODE_ENV`
- * for example) using the `webpack.DefinePlugin`.
+ * for example) using the `webpack.DefinePlugin`. Every constant's value is
+ * `JSON.stringify()`-ed first, so you don't have to remember.
  *
  * Special feature: Using `defineConstants` multiple times results in a single
  * DefinePlugin instance configured to do all the replacements.
@@ -186,9 +187,18 @@ function defineConstants (constants) {
 }
 
 function postDefineConstants (context) {
+  const stringify = (value) => JSON.stringify(value, null, 2)
+  const stringifiedConstants = mapProps(context.defineConstants, stringify)
+
   return {
     plugins: [
-      new webpack.DefinePlugin(context.defineConstants)
+      new webpack.DefinePlugin(stringifiedConstants)
     ]
   }
+}
+
+function mapProps (object, valueMapper) {
+  return Object.keys(object)
+    .map((propKey) => ({ [propKey]: valueMapper(object[propKey]) }))
+    .reduce((newObject, partial) => Object.assign(newObject, partial), {})
 }


### PR DESCRIPTION
Now that we have got `pre`/`post` hooks, `context` and `group()` it is easy to implement `defineConstants`.

Resolves #17.