### PR TITLE
Add js:next as a target

### DIFF
--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -69,7 +69,8 @@ function createBaseConfig (context) {
     },
 
     resolve: {
-      extensions: [ '', '.js', '.jsx', '.json' ]
+      extensions: [ '', '.js', '.jsx', '.json' ],
+      mainFields: ['browser', 'js:next', 'module', 'main']
     }
   }
 }

--- a/packages/webpack2/index.js
+++ b/packages/webpack2/index.js
@@ -69,7 +69,8 @@ function createBaseConfig (context) {
     },
 
     resolve: {
-      extensions: [ '.js', '.jsx', '.json' ]
+      extensions: [ '.js', '.jsx', '.json' ],
+      mainFields: ['browser', 'js:next', 'module', 'main']
     }
   }
 }


### PR DESCRIPTION
Maybe js:next should be added as a target for tree shaking (keep es2015 imports and exports, but transpile the rest).