### PR TITLE
Use webpack-merge 2.0, fix react hot loader

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,6 @@
     "webpack": "^1.13.2"
   },
   "dependencies": {
-    "webpack-merge": "^0.14.1"
+    "webpack-merge": "^2.0.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,6 @@
     "webpack": "^1.13.2"
   },
   "dependencies": {
-    "webpack-merge": "^2.0.0"
+    "webpack-merge": "^2.3.1"
   }
 }

--- a/packages/webpack-common/src/__tests__/devServer.test.js
+++ b/packages/webpack-common/src/__tests__/devServer.test.js
@@ -35,3 +35,22 @@ test('devServer() use webpack/hot/only-dev-server as default', (t) => {
   const config = block.post(context, currentConfig)
   t.deepEqual(config.entry.main, ['webpack/hot/only-dev-server'])
 })
+
+test('devServer.reactHot() prepend the loader', (t) => {
+  const currentConfig = {
+    module: {
+      loaders: [
+        {
+          test: '*.js',
+          loaders: [ 'babel-loader' ]
+        }
+      ]
+    }
+  }
+
+  const context = { webpack, fileType: () => '*.js' }
+  const block = devServer.reactHot()
+  const config = block(context, currentConfig)
+
+  t.deepEqual(config.module.loaders[0].loaders, [ 'react-hot' ])
+})

--- a/packages/webpack-common/src/extractText.js
+++ b/packages/webpack-common/src/extractText.js
@@ -18,7 +18,7 @@ export {
  */
 function getLoaderConfigByType (context, webpackConfig, fileType) {
   const loaderConfig = webpackConfig.module.loaders.find(
-    (loader) => regexEqual(loader.test, context.fileType(fileType))
+    (loader) => loader.test === context.fileType(fileType)
   )
 
   if (loaderConfig) {
@@ -26,12 +26,6 @@ function getLoaderConfigByType (context, webpackConfig, fileType) {
   } else {
     throw new Error(`${fileType} loader could not be found in webpack config.`)
   }
-}
-
-function regexEqual (x, y) {
-  return (x instanceof RegExp) && (y instanceof RegExp) &&
-   (x.source === y.source) && (x.global === y.global) &&
-   (x.ignoreCase === y.ignoreCase) && (x.multiline === y.multiline)
 }
 
 /**

--- a/packages/webpack-common/src/extractText.js
+++ b/packages/webpack-common/src/extractText.js
@@ -18,7 +18,7 @@ export {
  */
 function getLoaderConfigByType (context, webpackConfig, fileType) {
   const loaderConfig = webpackConfig.module.loaders.find(
-    (loader) => loader.test === context.fileType(fileType)
+    (loader) => regexEqual(loader.test, context.fileType(fileType))
   )
 
   if (loaderConfig) {
@@ -26,6 +26,12 @@ function getLoaderConfigByType (context, webpackConfig, fileType) {
   } else {
     throw new Error(`${fileType} loader could not be found in webpack config.`)
   }
+}
+
+function regexEqual (x, y) {
+  return (x instanceof RegExp) && (y instanceof RegExp) &&
+   (x.source === y.source) && (x.global === y.global) &&
+   (x.ignoreCase === y.ignoreCase) && (x.multiline === y.multiline)
 }
 
 /**

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -24,15 +24,6 @@ test('complete webpack config creation', (t) => {
   ])
 
   t.is(webpackConfig.module.loaders.length, 8)
-  t.deepEqual(webpackConfig.module.loaders[7], {
-    test: /\.(js|jsx)$/,
-    exclude: [ /\/node_modules\// ],
-    loaders: [ 'react-hot', 'babel-loader?{"cacheDirectory":true}' ]
-  })
-  t.deepEqual(webpackConfig.module.loaders[6], {
-    test: /\.(sass|scss)$/,
-    loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]
-  })
   t.deepEqual(webpackConfig.module.loaders[0], {
     test: /\.css$/,
     exclude: [ /\/node_modules\// ],
@@ -57,6 +48,15 @@ test('complete webpack config creation', (t) => {
   t.deepEqual(webpackConfig.module.loaders[5], {
     test: /\.(mp4|webm)$/,
     loaders: [ 'url-loader' ]
+  })
+  t.deepEqual(webpackConfig.module.loaders[6], {
+    test: /\.(sass|scss)$/,
+    loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]
+  })
+  t.deepEqual(webpackConfig.module.loaders[7], {
+    test: /\.(js|jsx)$/,
+    exclude: [ /\/node_modules\// ],
+    loaders: [ 'react-hot', 'babel-loader?{"cacheDirectory":true}' ]
   })
 
   t.deepEqual(webpackConfig.entry, { main: [ './src/main.js', 'webpack/hot/only-dev-server' ] })

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -17,43 +17,44 @@ test('complete webpack config creation', (t) => {
     }),
     sass(),
     devServer(),
+    devServer.reactHot(),
     devServer.proxy({
       '/api/*': { target: 'http://localhost:8080' }
     })
   ])
 
   t.is(webpackConfig.module.loaders.length, 8)
-  t.deepEqual(webpackConfig.module.loaders[0], {
+  t.deepEqual(webpackConfig.module.loaders[7], {
     test: /\.(js|jsx)$/,
     exclude: [ /\/node_modules\// ],
-    loaders: [ 'babel-loader?{"cacheDirectory":true}' ]
+    loaders: [ 'react-hot', 'babel-loader?{"cacheDirectory":true}' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[1], {
+  t.deepEqual(webpackConfig.module.loaders[6], {
     test: /\.(sass|scss)$/,
     loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[2], {
+  t.deepEqual(webpackConfig.module.loaders[0], {
     test: /\.css$/,
     exclude: [ /\/node_modules\// ],
     loaders: [ 'style-loader', 'css-loader?importLoaders=1&localIdentName=[name]--[local]--[hash:base64:5]&modules' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[3], {
+  t.deepEqual(webpackConfig.module.loaders[1], {
     test: /\.(gif|ico|jpg|jpeg|png|svg|webp)$/,
     loaders: [ 'file-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[4], {
+  t.deepEqual(webpackConfig.module.loaders[2], {
     test: /\.(eot|ttf|woff|woff2)(\?.*)?$/,
     loaders: [ 'file-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[5], {
+  t.deepEqual(webpackConfig.module.loaders[3], {
     test: /\.json$/,
     loaders: [ 'json-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[6], {
+  t.deepEqual(webpackConfig.module.loaders[4], {
     test: /\.(aac|m4a|mp3|oga|ogg|wav)$/,
     loaders: [ 'url-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[7], {
+  t.deepEqual(webpackConfig.module.loaders[5], {
     test: /\.(mp4|webm)$/,
     loaders: [ 'url-loader' ]
   })

--- a/packages/webpack2/__tests__/integration.test.js
+++ b/packages/webpack2/__tests__/integration.test.js
@@ -23,37 +23,37 @@ test('complete webpack config creation', (t) => {
   ])
 
   t.is(webpackConfig.module.loaders.length, 8)
-  t.deepEqual(webpackConfig.module.loaders[0], {
+  t.deepEqual(webpackConfig.module.loaders[7], {
     test: /\.(js|jsx)$/,
     exclude: [ /\/node_modules\// ],
     loaders: [ 'babel-loader?{"cacheDirectory":true}' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[1], {
+  t.deepEqual(webpackConfig.module.loaders[6], {
     test: /\.(sass|scss)$/,
     loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[2], {
+  t.deepEqual(webpackConfig.module.loaders[0], {
     test: /\.css$/,
     exclude: [ /\/node_modules\// ],
     loaders: [ 'style-loader', 'css-loader?importLoaders=1&localIdentName=[name]--[local]--[hash:base64:5]&modules' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[3], {
+  t.deepEqual(webpackConfig.module.loaders[1], {
     test: /\.(gif|ico|jpg|jpeg|png|svg|webp)$/,
     loaders: [ 'file-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[4], {
+  t.deepEqual(webpackConfig.module.loaders[2], {
     test: /\.(eot|ttf|woff|woff2)(\?.*)?$/,
     loaders: [ 'file-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[5], {
+  t.deepEqual(webpackConfig.module.loaders[3], {
     test: /\.json$/,
     loaders: [ 'json-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[6], {
+  t.deepEqual(webpackConfig.module.loaders[4], {
     test: /\.(aac|m4a|mp3|oga|ogg|wav)$/,
     loaders: [ 'url-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[7], {
+  t.deepEqual(webpackConfig.module.loaders[5], {
     test: /\.(mp4|webm)$/,
     loaders: [ 'url-loader' ]
   })

--- a/packages/webpack2/__tests__/integration.test.js
+++ b/packages/webpack2/__tests__/integration.test.js
@@ -23,15 +23,6 @@ test('complete webpack config creation', (t) => {
   ])
 
   t.is(webpackConfig.module.loaders.length, 8)
-  t.deepEqual(webpackConfig.module.loaders[7], {
-    test: /\.(js|jsx)$/,
-    exclude: [ /\/node_modules\// ],
-    loaders: [ 'babel-loader?{"cacheDirectory":true}' ]
-  })
-  t.deepEqual(webpackConfig.module.loaders[6], {
-    test: /\.(sass|scss)$/,
-    loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]
-  })
   t.deepEqual(webpackConfig.module.loaders[0], {
     test: /\.css$/,
     exclude: [ /\/node_modules\// ],
@@ -56,6 +47,15 @@ test('complete webpack config creation', (t) => {
   t.deepEqual(webpackConfig.module.loaders[5], {
     test: /\.(mp4|webm)$/,
     loaders: [ 'url-loader' ]
+  })
+  t.deepEqual(webpackConfig.module.loaders[6], {
+    test: /\.(sass|scss)$/,
+    loaders: [ 'style-loader', 'css-loader', 'sass-loader' ]
+  })
+  t.deepEqual(webpackConfig.module.loaders[7], {
+    test: /\.(js|jsx)$/,
+    exclude: [ /\/node_modules\// ],
+    loaders: [ 'babel-loader?{"cacheDirectory":true}' ]
   })
 
   t.deepEqual(webpackConfig.entry, {


### PR DESCRIPTION
Fix #56 

All I've done is add unit test for reactHot and update webpack-merge to 2.0.0.

It's a big jump in the version, but it ensures merging the loaders is done correctly for react-hot. However, it looks like the loaders order is now changed a little bit. Not a big deal, but worth testing enough before pushing this.