### PR TITLE
Webpack 2 compatible PostCSS block + improvements

### DIFF
--- a/packages/postcss2/CHANGELOG.md
+++ b/packages/postcss2/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @webpack-blocks/postcss2 - Changelog
+
+## 0.1.0
+
+Initial release.

--- a/packages/postcss2/README.md
+++ b/packages/postcss2/README.md
@@ -1,0 +1,67 @@
+# Webpack blocks - PostCSS for Webpack 2
+
+[![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
+[![NPM Version](https://img.shields.io/npm/v/@webpack-blocks/postcss.svg)](https://www.npmjs.com/package/@webpack-blocks/postcss)
+
+This is the `postcss` block providing PostCSS configuration.
+
+
+## Usage
+
+***IMPORTANT:** Loading postcss plugins inside the webpack 2 (as of webpack@2.2.0-rc.3) configuration does not work right now, which is why we currently use postcss.config.js. Reference: https://github.com/postcss/postcss-loader/issues/125#issuecomment-257127969*
+
+### webpack.config.js
+```js
+const { createConfig } = require('@webpack-blocks/webpack')
+const postcss = require('@webpack-blocks/postcss')
+
+module.exports = createConfig([
+  postcss([
+    // You'd normally pass in your plugins here. Please check the note about
+    // configuring PostCSS plugins above!
+  ])
+])
+```
+
+### postcss.config.js
+
+```js
+module.exports = {
+  plugins: {
+    'autoprefixer': {
+      { browsers: ['last 2 versions'] }
+    }
+  }
+})
+```
+
+### Specificying postcss-loader options
+
+If you want to specifiy `syntax`, `stringifier` or `parser`, f.e. for using `postcss-scss`, you can pass an options object as second argument.
+
+```js
+const { createConfig } = require('@webpack-blocks/webpack')
+const postcss = require('@webpack-blocks/postcss')
+const autoprefixer = require('autoprefixer')
+const scss = require('postcss-scss')
+
+module.exports = createConfig([
+  postcss([
+    // You'd normally pass in your plugins here. Please check the note about
+    // configuring PostCSS plugins above!
+  ], {
+    syntax: 'postcss-scss',
+    // stringifier: 'custom-stringifier',
+    // parser: 'custom-parser'
+  })
+])
+```
+
+
+## Webpack blocks
+
+Check out the
+
+👉 [Main Documentation](https://github.com/andywer/webpack-blocks)
+
+Released under the terms of the MIT license.

--- a/packages/postcss2/index.js
+++ b/packages/postcss2/index.js
@@ -1,0 +1,64 @@
+/**
+ * PostCSS webpack block.
+ *
+ * @see https://github.com/postcss/postcss-loader
+ */
+module.exports = postcss
+
+/**
+ * Adds `postcss-loader` block to your webpack configuration. `postcss-loader`
+ * options can be supplied with `plugins`, `options.parser`, `options.stringifier` or
+ * `options.syntax`.
+ *
+ * `postcss-loader` tries to use `postcss.config.js` file when no arguments are
+ * supplied.
+ *
+ * You can exclude files with `options.exclude`.
+ *
+ * @see https://github.com/postcss/postcss-loader
+ *
+ * @param {PostCSSPlugin[]}           [plugins]                             An array of {@link http://api.postcss.org/global.html#pluginFunction|PostCSS plugins}.
+ * @param {object}                    [options]
+ * @param {PostCSSParser|string}      [options.parser]                      Must be a {@link http://www.google.com|PostCSS parser} instance or the module name as string, e.g. 'postcss-scss'.
+ * @param {PostCSSStringifier|string} [options.stringifier]                 Must be a {@link http://api.postcss.org/global.html#stringifier|PostCSS stringifier} instance or the module name as string, e.g. 'postcss-scss'.
+ * @param {PostCSSSyntax|string}      [options.syntax]                      Must be a {@link http://api.postcss.org/global.html#syntax|PostCSS syntax} instance or the module name as string, e.g. 'postcss-scss'.
+ * @param {RegExp|Function|string}    [options.exclude=/\/node_modules\//]  Files excluded from this loader
+ * @return {Function}
+ */
+function postcss (plugins, options) {
+  options = options || {}
+  const exclude = options.exclude || /\/node_modules\//
+
+  /* TODO: Remove this condition as soon as loading plugins with webpack 2 works. */
+  if (plugins) {
+    throw new Error(`Loading postcss plugins with webpack 2 (as of webpack@2.2.0-rc.3) does not work right now. Please use a postcss.config.js file! Reference: https://github.com/postcss/postcss-loader/issues/125#issuecomment-257127969`)
+  }
+
+  return (context) => Object.assign({
+    module: {
+      rules: [
+        {
+          test: context.fileType('text/css'),
+          exclude: Array.isArray(exclude) ? exclude : [ exclude ],
+          use: [
+            {
+              loader: 'style-loader'
+            },
+            {
+              loader: 'css-loader'
+            },
+            {
+              loader: 'postcss-loader',
+              options: {
+                parser: options.parser,
+                stringifier: options.stringifier,
+                syntax: options.syntax,
+                plugins: plugins
+              }
+            }
+          ]
+        }
+      ]
+    }
+  })
+}

--- a/packages/postcss2/package.json
+++ b/packages/postcss2/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@webpack-blocks/postcss2",
+  "version": "0.1.0",
+  "description": "Webpack block for PostCSS.",
+  "main": "lib/index",
+  "license": "MIT",
+  "author": "Andy Wermke <andy@dev.next-step-software.com>",
+  "scripts": {
+    "test": "standard",
+    "prepublish": "npm test"
+  },
+  "engines": {
+    "node": ">= 4.0"
+  },
+  "repository": "andywer/webpack-blocks",
+  "bugs": "https://github.com/andywer/webpack-blocks/issues",
+  "dependencies": {
+    "postcss-loader": "^1.2.0"
+  },
+  "devDependencies": {
+    "standard": "^8.1.0"
+  }
+}


### PR DESCRIPTION
Hi folks!

So, like mentioned in #68, I also encountered errors while using the latest webpack2 (rc.3 as of this moment) with the postcss block. After researching and testing a lot of stuff, I identified two issues. I'm not even sure if this is something @andywer wants to have, but as I did this for a project of my own, I thought why not submitting this; it at least could help somebody using webpack 2.

**Issues with current postcss block**
1. In webpack 2, adding a postcss property to the root of the webpack configuration object is invalid (see http://javascriptplayground.com/blog/2016/10/moving-to-webpack-2/#configuring-loaders)
2. After changing to the new webpack 2 style of configuring loaders, there are still errors. In webpack 2, passing in plugins to the postcss-loader within the webpack configuration is currently broken (see https://github.com/postcss/postcss-loader/issues/125#issuecomment-257127969)

So I made a "postcss2" block where I changed several things. I'm not sure if all of these changes are like the maintainers of webpack-blocks want them to be, I'll be happy to adapt this! There definitely are points which need discussion. 

**Changes made in the postcss 2 block**
- Used webpack 2 syntax "rules" instead of "loaders". "Loaders" is the webpack 1 style of defining loaders, which is backwards-compatible, but AFAIK will be deprecated. IMHO, this should be changed for all webpack 2 block. I'll be happy to create a pull request for the other blocks if this is wanted. See http://javascriptplayground.com/blog/2016/10/moving-to-webpack-2/#moduleloaders--modulerules
- Because of the current issue with webpack 2 and postcss-loader, loading plugins within the webpack configuration (like described above; see https://github.com/postcss/postcss-loader/issues/125#issuecomment-257127969) doesn't work. I changed the README to reflect this and added an error when someone tries to add plugins to the block. I'm not sure if this is what you guys want, though. Any ideas to do this better? See https://github.com/nightgrey/webpack-blocks/blob/88da42683768fecfdb8df5c2f233a795e56dd5b2/packages/postcss2/index.js#L32
- I added the possibility to pass other postcss options, like specifiying a parser, stringifier or syntax. This is needed to, for example, parse the SCSS syntax. I'd be happy to do this for the current postcss block, too!
- I improved/corrected the JSDoc comments a bit. For example, https://github.com/andywer/webpack-blocks/blob/1744d2878b6fbeb3bbd479597ab2e9ff5f85cf48/packages/postcss/index.js#L12 isn't actually valid; it would've to be `|` instead of `,`. There are some other improvements and more details, too. I'd be happy to do this for the current postcss block, too!

So, yeah, what do you say? Like already said, some things can easily be added to the current PostCSS block and with some others, I'm not sure if there are better solutions. I'm happy about any comment, thoughts or criticism on this. 

Edit: --amend'ed/updated my commit. Forgot to run standard and had some extra spaces, oops. Fixed.