### PR TITLE
PostCSS custom options

### DIFF
--- a/packages/postcss/CHANGELOG.md
+++ b/packages/postcss/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/postcss - Changelog
 
+## 0.3.1
+
+- Supporting custom PostCSS options now (`parser`, `stringifier`, `syntax`)
+
 ## 0.3.0
 
 - Adapted to new API: Using `context` now

--- a/packages/postcss/README.md
+++ b/packages/postcss/README.md
@@ -16,9 +16,21 @@ const autoprefixer = require('autoprefixer')
 module.exports = createConfig([
   postcss([
     autoprefixer({ browsers: ['last 2 versions'] })
-  ])
+  ], { /* custom PostCSS options */ })
 ])
 ```
+
+
+## Options
+
+#### parser *(optional)*
+Package name of a custom PostCSS parser to use. Pass for instance `'sugarss'` to be able to write indent-based CSS.
+
+#### stringifier *(optional)*
+Package name of a custom PostCSS stringifier to use.
+
+#### syntax *(optional)*
+Package name of a custom PostCSS syntax to use. The package must export a `parse` and a `stringify` function.
 
 
 ## Webpack blocks

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -7,14 +7,25 @@
 module.exports = postcss
 
 /**
- * @param {PostCSSPlugin[]} [plugins]                     Will read `postcss.config.js` file if not supplied.
+ * @param {PostCSSPlugin[]} [plugins]                   Will read `postcss.config.js` file if not supplied.
  * @param {object}          [options]
- * @param {RegExp, Function, string}  [options.exclude]   Directories to exclude.
+ * @param {RegExp|Function|string}  [options.exclude]     Directories to exclude.
+ * @param {string}                  [options.parser]      Package name of custom PostCSS parser to use.
+ * @param {string}                  [options.stringifier] Package name of custom PostCSS stringifier to use.
+ * @param {string}                  [options.syntax]      Package name of custom PostCSS parser/stringifier to use.
  * @return {Function}
  */
 function postcss (plugins, options) {
   options = options || {}
   const exclude = options.exclude || /\/node_modules\//
+
+  // https://github.com/postcss/postcss-loader#options
+  const postcssOptions = Object.assign(
+    {},
+    options.parser && { parser: options.parser },
+    options.stringifier && { stringifier: options.stringifier },
+    options.syntax && { syntax: options.syntax }
+  )
 
   return (context) => Object.assign({
     module: {
@@ -22,7 +33,7 @@ function postcss (plugins, options) {
         {
           test: context.fileType('text/css'),
           exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-          loaders: [ 'style-loader', 'css-loader', 'postcss-loader' ]
+          loaders: [ 'style-loader', 'css-loader', 'postcss-loader?' + JSON.stringify(postcssOptions) ]
         }
       ]
     }

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/postcss",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Webpack block for PostCSS.",
   "main": "lib/index",
   "license": "MIT",


### PR DESCRIPTION
Adds support for custom PostCSS options (`parser`, `stringifier`, `syntax`).

@nightgrey This has been part of your PR #69 as well. I separated it, since this feature works independently from the webpack 2 changes. Feel free to review :)