### PR TITLE
Webpack2: Remove json-loader

### DIFF
--- a/packages/webpack2/CHANGELOG.md
+++ b/packages/webpack2/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/webpack2 - Changelog
 
+## 0.3.1
+
+- Remove the `json-loader` config & depedency, since webpack 2 comes with a default json-loader config (#63)
+
 ## 0.3.0
 
 Initial non-beta release. Aligned with the v0.3 release changes.

--- a/packages/webpack2/__tests__/integration.test.js
+++ b/packages/webpack2/__tests__/integration.test.js
@@ -22,7 +22,7 @@ test('complete webpack config creation', (t) => {
     })
   ])
 
-  t.is(webpackConfig.module.loaders.length, 8)
+  t.is(webpackConfig.module.loaders.length, 7)
   t.deepEqual(webpackConfig.module.loaders[0], {
     test: /\.(js|jsx)$/,
     exclude: [ /\/node_modules\// ],
@@ -46,14 +46,10 @@ test('complete webpack config creation', (t) => {
     loaders: [ 'file-loader' ]
   })
   t.deepEqual(webpackConfig.module.loaders[5], {
-    test: /\.json$/,
-    loaders: [ 'json-loader' ]
-  })
-  t.deepEqual(webpackConfig.module.loaders[6], {
     test: /\.(aac|m4a|mp3|oga|ogg|wav)$/,
     loaders: [ 'url-loader' ]
   })
-  t.deepEqual(webpackConfig.module.loaders[7], {
+  t.deepEqual(webpackConfig.module.loaders[6], {
     test: /\.(mp4|webm)$/,
     loaders: [ 'url-loader' ]
   })

--- a/packages/webpack2/index.js
+++ b/packages/webpack2/index.js
@@ -56,9 +56,6 @@ function createBaseConfig (context) {
           test: context.fileType('application/font'),
           loaders: [ 'file-loader' ]
         }, {
-          test: context.fileType('application/json'),
-          loaders: [ 'json-loader' ]
-        }, {
           test: context.fileType('audio'),
           loaders: [ 'url-loader' ]
         }, {

--- a/packages/webpack2/package.json
+++ b/packages/webpack2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/webpack2",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Webpack block for the webpack 2.x base configuration.",
   "license": "MIT",
   "author": "Andy Wermke <andy@dev.next-step-software.com>",

--- a/packages/webpack2/package.json
+++ b/packages/webpack2/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "css-loader": "^0.25.0",
     "file-loader": "^0.9.0",
-    "json-loader": "^0.5.4",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.0-rc.1",


### PR DESCRIPTION
Webpack 2 comes with a default `json-loader` config. We will just use that by default.

Resolves #63. Read that issue for details.