### PR TITLE
Critical fix: Make PostCSS inlined plugin config work with webpack 2

### DIFF
--- a/packages/postcss/CHANGELOG.md
+++ b/packages/postcss/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/postcss - Changelog
 
+## 0.3.2
+
+- Bug fix: PostCSS plugin configuration now works with webpack 2 ([#68](https://github.com/andywer/webpack-blocks/issues/68))
+
 ## 0.3.1
 
 - Supporting custom PostCSS options now (`parser`, `stringifier`, `syntax`)

--- a/packages/postcss/README.md
+++ b/packages/postcss/README.md
@@ -20,6 +20,17 @@ module.exports = createConfig([
 ])
 ```
 
+Instead of passing the PostCSS plugins as an array you can also create a `postcss.config.js` file containing the plugin configuration (see [PostCSS loader usage](https://github.com/postcss/postcss-loader#usage)):
+
+```js
+// postcss.config.js
+module.exports = {
+  plugins: [
+    require('precss')
+  ]
+}
+```
+
 
 ## Options
 

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -27,17 +27,36 @@ function postcss (plugins, options) {
     options.syntax && { syntax: options.syntax }
   )
 
-  return (context) => Object.assign({
-    module: {
-      loaders: [
-        {
-          test: context.fileType('text/css'),
-          exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-          loaders: [ 'style-loader', 'css-loader', 'postcss-loader?' + JSON.stringify(postcssOptions) ]
-        }
+  return (context) => Object.assign(
+    {
+      module: {
+        loaders: [
+          {
+            test: context.fileType('text/css'),
+            exclude: Array.isArray(exclude) ? exclude : [ exclude ],
+            loaders: [ 'style-loader', 'css-loader', 'postcss-loader?' + JSON.stringify(postcssOptions) ]
+          }
+        ]
+      }
+    },
+    plugins ? createPostcssPluginsConfig(context.webpack, plugins) : {}
+  )
+}
+
+function createPostcssPluginsConfig (webpack, plugins) {
+  const isWebpack2 = typeof webpack.validateSchema !== 'undefined'
+
+  if (isWebpack2) {
+    return {
+      plugins: [
+        new webpack.LoaderOptionsPlugin({
+          options: { postcss: plugins }
+        })
       ]
     }
-  }, plugins ? {
-    postcss: plugins
-  } : {})
+  } else {
+    return {
+      postcss: plugins
+    }
+  }
 }

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webpack-blocks/postcss",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Webpack block for PostCSS.",
   "main": "lib/index",
   "license": "MIT",

--- a/packages/webpack2/__e2e-fixtures__/babel-postcss-extract-text/postcss.config.js
+++ b/packages/webpack2/__e2e-fixtures__/babel-postcss-extract-text/postcss.config.js
@@ -1,7 +1,0 @@
-const precss = require('precss')
-
-module.exports = {
-  plugins: [
-    precss
-  ]
-}

--- a/packages/webpack2/__e2e-fixtures__/babel-postcss-extract-text/webpack.config.js
+++ b/packages/webpack2/__e2e-fixtures__/babel-postcss-extract-text/webpack.config.js
@@ -12,6 +12,7 @@ const babel = require('@webpack-blocks/babel6')
 const postcss = require('@webpack-blocks/postcss')
 const extractText = require('@webpack-blocks/extract-text2')
 const path = require('path')
+const precss = require('precss')
 
 module.exports = createConfig([
   entryPoint(
@@ -21,7 +22,9 @@ module.exports = createConfig([
     path.join(__dirname, 'build/bundle.js')
   ),
   babel(),
-  postcss(),
+  postcss([
+    precss
+  ]),
   extractText(
     path.join('styles.css')
   ),


### PR DESCRIPTION
You could not configure the PostCSS plugins from within your webpack config before when using webpack 2. This has now been fixed. No difference in usage, just update the `postcss` block.

Fixes #68. Replaces #69.