### PR TITLE
Vanilla createConfig()

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ module.exports = createConfig([
 ## You might want to know
 
 <details>
+<summary>Can I get rid of the default loaders?</summary>
+
+The `createConfig()` function sets some generic default loaders. This should not be a problem. If does happen to be a problem you can also create a "vanilla" configuration (without the defaults) by using `createConfig.vanilla()` instead.
+</details>
+
+<details>
 <summary>How does env() work?</summary>
 
 You might wonder how `env('development', [ ... ])` works? It just checks the NODE_ENV environment variable and only applies its contained webpack blocks if it matches.

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/webpack - Changelog
 
+## Next release
+
+- Provide `createConfig.vanilla()` (see [#80](https://github.com/andywer/webpack-blocks/issues/80))
+
 ## 0.3.0
 
 - Provide `group()` for creating presets

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -35,7 +35,11 @@ module.exports = createConfig([
 
 #### createConfig(configSetter: Function[]): object
 
-Takes an array of config setters (the functions returned by invoked webpack blocks), invokes them and returns the resulting webpack config object.
+Takes an array of config setters (the functions returned by invoked webpack blocks), invokes them and returns the resulting webpack config object. Already sets some generic default config, like default CSS, font and image file loaders.
+
+#### createConfig.vanilla(configSetter: Function[]): object
+
+Works just like `createConfig()`, but provides no default configuration whatsoever. Use it only if you want to get rid of the default loaders for some reason.
 
 #### group(configSetters: Function[]): Function
 

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -82,3 +82,20 @@ test('complete webpack config creation', (t) => {
     'devServer', 'devtool', 'entry', 'module', 'output', 'plugins', 'resolve'
   ])
 })
+
+test('createConfig.vanilla() creates configurations without defaults', (t) => {
+  const webpackConfig = createConfig.vanilla([
+    entryPoint('./src/main.js'),
+    setOutput('./build/bundle.js')
+  ])
+
+  t.deepEqual(webpackConfig, {
+    entry: {
+      main: [ './src/main.js' ]
+    },
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve('./build')
+    }
+  })
+})

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -13,6 +13,7 @@ exports.group = core.group
 exports.webpack = webpack
 
 exports.createConfig = createConfig
+exports.createConfig.vanilla = createVanillaConfig
 
 exports.addPlugins = common.addPlugins
 exports.customConfig = common.customConfig
@@ -24,6 +25,22 @@ exports.setContext = common.setContext
 exports.setDevTool = common.setDevTool
 exports.setOutput = common.setOutput
 exports.sourceMaps = common.sourceMaps
+
+/**
+ * Takes an array of webpack blocks and creates a webpack config out of them.
+ * Each webpack block is a callback function which will be invoked to return a
+ * partial webpack config. These partial configs are merged to create the
+ * final, complete webpack config that will be returned.
+ *
+ * Wraps @webpack-blocks/core's `createConfig` without `createConfig()`'s usual
+ * default config.
+ *
+ * @param {Function[]} configSetters  Array of functions as returned by webpack blocks.
+ * @return {object}                   Webpack config object.
+ */
+function createVanillaConfig (configSetters) {
+  return core.createConfig(webpack, configSetters)
+}
 
 /**
  * Takes an array of webpack blocks and creates a webpack config out of them.

--- a/packages/webpack2/CHANGELOG.md
+++ b/packages/webpack2/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/webpack2 - Changelog
 
+## Next release
+
+- Provide `createConfig.vanilla()` (see [#80](https://github.com/andywer/webpack-blocks/issues/80))
+
 ## 0.3.1
 
 - Remove the `json-loader` config & depedency, since webpack 2 comes with a default json-loader config (#63)

--- a/packages/webpack2/README.md
+++ b/packages/webpack2/README.md
@@ -45,7 +45,11 @@ Make sure you use the appropriate webpack blocks:
 
 #### createConfig(configSetter: Function[]): object
 
-Takes an array of config setters (the functions returned by invoked webpack blocks), invokes them and returns the resulting webpack config object.
+Takes an array of config setters (the functions returned by invoked webpack blocks), invokes them and returns the resulting webpack config object. Already sets some generic default config, like default CSS, font and image file loaders.
+
+#### createConfig.vanilla(configSetter: Function[]): object
+
+Works just like `createConfig()`, but provides no default configuration whatsoever. Use it only if you want to get rid of the default loaders for some reason.
 
 #### group(configSetters: Function[]): Function
 

--- a/packages/webpack2/__tests__/integration.test.js
+++ b/packages/webpack2/__tests__/integration.test.js
@@ -80,3 +80,20 @@ test('complete webpack config creation', (t) => {
     'devServer', 'devtool', 'entry', 'module', 'output', 'plugins', 'resolve'
   ])
 })
+
+test('createConfig.vanilla() creates configurations without defaults', (t) => {
+  const webpackConfig = createConfig.vanilla([
+    entryPoint('./src/main.js'),
+    setOutput('./build/bundle.js')
+  ])
+
+  t.deepEqual(webpackConfig, {
+    entry: {
+      main: [ './src/main.js' ]
+    },
+    output: {
+      filename: 'bundle.js',
+      path: path.resolve('./build')
+    }
+  })
+})

--- a/packages/webpack2/index.js
+++ b/packages/webpack2/index.js
@@ -13,6 +13,7 @@ exports.group = core.group
 exports.webpack = webpack
 
 exports.createConfig = createConfig
+exports.createConfig.vanilla = createVanillaConfig
 
 exports.addPlugins = common.addPlugins
 exports.customConfig = common.customConfig
@@ -24,6 +25,22 @@ exports.setContext = common.setContext
 exports.setDevTool = common.setDevTool
 exports.setOutput = common.setOutput
 exports.sourceMaps = common.sourceMaps
+
+/**
+ * Takes an array of webpack blocks and creates a webpack config out of them.
+ * Each webpack block is a callback function which will be invoked to return a
+ * partial webpack config. These partial configs are merged to create the
+ * final, complete webpack config that will be returned.
+ *
+ * Wraps @webpack-blocks/core's `createConfig` without `createConfig()`'s usual
+ * default config.
+ *
+ * @param {Function[]} configSetters  Array of functions as returned by webpack blocks.
+ * @return {object}                   Webpack config object.
+ */
+function createVanillaConfig (configSetters) {
+  return core.createConfig(webpack, configSetters)
+}
 
 /**
  * Takes an array of webpack blocks and creates a webpack config out of them.


### PR DESCRIPTION
Adds `createConfig.vanilla()` to opt-out of the usual defaults that `createConfig()` normally sets automatically.

Fixes #80.