### PR TITLE
Drop `node_modules/` exclusion from default css-loader

### DIFF
--- a/packages/css-modules/CHANGELOG.md
+++ b/packages/css-modules/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/css-modules - Changelog
 
+## Next release
+
+- Breaking change: Dropped the default `node_modules/` exclusion
+
 ## 0.3.0
 
 - Adapted to new API: Using `context` now

--- a/packages/css-modules/index.js
+++ b/packages/css-modules/index.js
@@ -20,18 +20,18 @@ function cssModules (options) {
     ? '[hash:base64:10]'
     : '[name]--[local]--[hash:base64:5]'
 
-  const exclude = options.exclude || /\/node_modules\//
   const importLoaders = options.importLoaders || 1
   const localIdentName = options.localIdentName || localIdentDefault
 
   return (context) => ({
     module: {
       loaders: [
-        {
+        Object.assign({
           test: context.fileType('text/css'),
-          exclude: Array.isArray(exclude) ? exclude : [ exclude ],
           loaders: [ 'style-loader', 'css-loader?' + stringifyQueryParams({ importLoaders, localIdentName, modules: true }) ]
-        }
+        }, options.exclude ? {
+          exclude: Array.isArray(options.exclude) ? options.exclude : [ options.exclude ]
+        } : {})
       ]
     }
   })

--- a/packages/postcss/CHANGELOG.md
+++ b/packages/postcss/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/postcss - Changelog
 
+## Next release
+
+- Breaking change: Dropped the default `node_modules/` exclusion
+
 ## 0.3.2
 
 - Bug fix: PostCSS plugin configuration now works with webpack 2 ([#68](https://github.com/andywer/webpack-blocks/issues/68))

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -17,7 +17,6 @@ module.exports = postcss
  */
 function postcss (plugins, options) {
   options = options || {}
-  const exclude = options.exclude || /\/node_modules\//
 
   // https://github.com/postcss/postcss-loader#options
   const postcssOptions = Object.assign(
@@ -31,11 +30,12 @@ function postcss (plugins, options) {
     {
       module: {
         loaders: [
-          {
+          Object.assign({
             test: context.fileType('text/css'),
-            exclude: Array.isArray(exclude) ? exclude : [ exclude ],
             loaders: [ 'style-loader', 'css-loader', 'postcss-loader?' + JSON.stringify(postcssOptions) ]
-          }
+          }, options.exclude ? {
+            exclude: Array.isArray(options.exclude) ? options.exclude : [ options.exclude ]
+          } : {})
         ]
       }
     },

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - Provide `createConfig.vanilla()` (see [#80](https://github.com/andywer/webpack-blocks/issues/80))
+- Breaking change: Removed `node_modules/` exclusion from default css-loader
 
 ## 0.3.0
 

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -25,7 +25,6 @@ test('complete webpack config creation', (t) => {
   t.is(webpackConfig.module.loaders.length, 8)
   t.deepEqual(webpackConfig.module.loaders[0], {
     test: /\.css$/,
-    exclude: [ /\/node_modules\// ],
     loaders: [ 'style-loader', 'css-loader?importLoaders=1&localIdentName=[name]--[local]--[hash:base64:5]&modules' ]
   })
   t.deepEqual(webpackConfig.module.loaders[1], {

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -64,7 +64,6 @@ function createBaseConfig (context) {
       loaders: [
         {
           test: context.fileType('text/css'),
-          exclude: [ /\/node_modules\// ],
           loaders: [ 'style-loader', 'css-loader' ]
         }, {
           test: context.fileType('image'),

--- a/packages/webpack2/CHANGELOG.md
+++ b/packages/webpack2/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next release
 
 - Provide `createConfig.vanilla()` (see [#80](https://github.com/andywer/webpack-blocks/issues/80))
+- Breaking change: Removed `node_modules/` exclusion from default css-loader
 
 ## 0.3.1
 

--- a/packages/webpack2/__tests__/integration.test.js
+++ b/packages/webpack2/__tests__/integration.test.js
@@ -25,7 +25,6 @@ test('complete webpack config creation', (t) => {
   t.is(webpackConfig.module.loaders.length, 7)
   t.deepEqual(webpackConfig.module.loaders[0], {
     test: /\.css$/,
-    exclude: [ /\/node_modules\// ],
     loaders: [ 'style-loader', 'css-loader?importLoaders=1&localIdentName=[name]--[local]--[hash:base64:5]&modules' ]
   })
   t.deepEqual(webpackConfig.module.loaders[1], {

--- a/packages/webpack2/index.js
+++ b/packages/webpack2/index.js
@@ -64,7 +64,6 @@ function createBaseConfig (context) {
       loaders: [
         {
           test: context.fileType('text/css'),
-          exclude: [ /\/node_modules\// ],
           loaders: [ 'style-loader', 'css-loader' ]
         }, {
           test: context.fileType('image'),


### PR DESCRIPTION
The `node_modules` directory should not be excluded from the css-loader (esp. not implicitly).

Fixes #83.