### PR TITLE
Fix optionalness of plugins param

### DIFF
--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -16,6 +16,7 @@ module.exports = postcss
  * @return {Function}
  */
 function postcss (plugins, options) {
+  plugins = plugins || []
   options = options || {}
 
   // https://github.com/postcss/postcss-loader#options


### PR DESCRIPTION
**Current behavior**

This:

```js
createConfig([
  postcss(),
])
```

produces a warning “PostCSS Config could not be loaded. Please check your PostCSS Config”.

But this:

```js
createConfig([
  postcss([]),  // Empty plugins array
])
```

works fine.



This pull request removes the warning.