### PR TITLE
Happypack block

### DIFF
--- a/packages/happypack/README.md
+++ b/packages/happypack/README.md
@@ -1,0 +1,33 @@
+# Webpack blocks - HappyPack
+
+This is the `happypack` block providing an easy to use block to support Happypack cache and mutli thread execution.
+
+
+## Usage
+
+```js
+const { createConfig } = require('@webpack-blocks/webpack')
+const babel = require('@webpack-blocks/babel')
+const sass = require('@webpack-blocks/sass')
+const happypack = require('@webpack-blocks/happypack')
+
+module.exports = createConfig([
+  happypack([
+  	babel(),
+  	sass(),
+  ], {threads: 4})
+])
+```
+
+## Options
+
+- An array of `webpack-blocks` that are compatible with happypack, [Here the full list](https://github.com/amireh/happypack/wiki/Webpack-Loader-API-Support)
+- Happypack options [Here](https://github.com/amireh/happypack/wiki/Webpack-Loader-API-Support)
+
+## Webpack blocks
+
+Check out the
+
+👉 [Main Documentation](https://github.com/andywer/webpack-blocks)
+
+Released under the terms of the MIT license.

--- a/packages/happypack/index.js
+++ b/packages/happypack/index.js
@@ -62,7 +62,7 @@ function happyfyConfig(configSnippet, _, happypackConfig) {
  * Takes an array, a function or something falsy and returns the array, the
  * function wrapped in an array or an empty array, respectively.
  */
-function toArray(value) {https://github.com/fenos/webpack-blocks
+function toArray(value) {
   if (value) {
     return Array.isArray(value) ? value : [value]
   } else {

--- a/packages/happypack/index.js
+++ b/packages/happypack/index.js
@@ -1,0 +1,71 @@
+const { group } = require('@webpack-blocks/core')
+const HappyPack = require('happypack');
+const os = require('os');
+
+module.exports = happypack
+
+function happypack(blocks, configs = {}) {
+  return group(blocks.map((block) => happyfyBlock(block, configs)))
+}
+
+/**
+ * Returns a new block wrapping `block` that creates a happypack loader config.
+ */
+function happyfyBlock(block, config) {
+  const happyBlock = happyfySetter(block, config)
+  const pre = toArray(block.pre)
+  const post = toArray(block.post).map(postHook => happyfySetter(postHook, config))
+
+  return Object.assign(happyBlock, { pre, post })
+}
+
+/**
+ * Takes a block or a post hook and returns a wrapping function that creates a happypack loader config.
+ */
+function happyfySetter(setter, happypackConfig) {
+  return (context, config) => happyfyConfig(setter(context, config), context, happypackConfig)
+}
+
+/**
+ * Transforms a non-happypack loader config into a happypack loader config.
+ */
+function happyfyConfig(configSnippet, _, happypackConfig) {
+  if (configSnippet.module && configSnippet.module.loaders) {
+    const plugins = [];
+    const loaders = configSnippet.module.loaders.map((loader, id) => {
+      const happypackplugin = new HappyPack(Object.assign({
+        id: `loader${id}`,
+        loaders: loader.loaders,
+        threads: os.cpus().length,
+      }, happypackConfig));
+
+      plugins.push(happypackplugin);
+
+      return {
+        test: loader.test,
+        loader: `happypack/loader?id=loader${id}`,
+        exclude: loader.exclude || [],
+      }
+    });
+
+    return {
+      module: {
+        loaders,
+      },
+      plugins,
+    }
+  }
+  return {};
+}
+
+/**
+ * Takes an array, a function or something falsy and returns the array, the
+ * function wrapped in an array or an empty array, respectively.
+ */
+function toArray(value) {https://github.com/fenos/webpack-blocks
+  if (value) {
+    return Array.isArray(value) ? value : [value]
+  } else {
+    return []
+  }
+}

--- a/packages/happypack/package.json
+++ b/packages/happypack/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@webpack-blocks/happypack",
+  "version": "0.0.1",
+  "description": "Webpack block for happypack",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "engines": {
+    "node": ">= 4.0"
+  },
+  "keywords": [
+    "webpack",
+    "webpack-blocks",
+    "happypack"
+  ],
+  "repository": "andywer/webpack-blocks",
+  "bugs": "https://github.com/andywer/webpack-blocks/issues",
+  "author": "Fabrizio Fenoglio",
+  "license": "MIT",
+  "dependencies": {
+    "happypack": "^3.0.3"
+  }
+}


### PR DESCRIPTION
As discussed in the issue #14 will be very nice to have a `happypack` block wich allows us to easily implement `Happypack` features to improve the performance of the build.

@andywer found a neat way to implement the block using the `webpack-block` API, big thanks for that. 

With a bit of delay I finish it up, so here you go.

```js
module.exports = createConfig([
  happypack([
     babel(),
     sass(),
  ])
])
```

**Note:**
I'm using the loader for a while now, and unfortunately, I haven't seen any improvements in terms of build speed in either **watch mode** and **production build** This Pr will also help to debug the problem.