### PR TITLE
Fix react hot loader

### DIFF
--- a/packages/webpack-common/src/devServer.js
+++ b/packages/webpack-common/src/devServer.js
@@ -94,7 +94,7 @@ function reactHot (options = {}) {
       loaders: [{
         test: context.fileType('application/javascript'),
         exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-        loaders: [ 'react-hot' ]
+        loaders: [ 'react-hot-loader/webpack' ]
       }]
     }
   })


### PR DESCRIPTION
It is no longer supported not having -loader in webpack 2 and we need /webpack if we are not using it with babel. Maybe this plugin has not been updated to work with the last version of react-hot-loader and webpack2? (this is shared)