### PR TITLE
webpack-common: hotOnly by default for devServer

### DIFF
--- a/packages/webpack-common/src/__tests__/devServer.integration.test.js
+++ b/packages/webpack-common/src/__tests__/devServer.integration.test.js
@@ -22,6 +22,7 @@ test('devServer() without options provides expected defaults', (t) => {
     },
     devServer: {
       hot: true,
+      hotOnly: true,
       historyApiFallback: true,
       inline: true
     },
@@ -51,6 +52,7 @@ test('devServer() uses custom options and can be composed', (t) => {
     },
     devServer: {
       hot: true,
+      hotOnly: true,
       historyApiFallback: true,
       inline: false
     },

--- a/packages/webpack-common/src/__tests__/devServer.integration.test.js
+++ b/packages/webpack-common/src/__tests__/devServer.integration.test.js
@@ -18,7 +18,7 @@ test('devServer() without options provides expected defaults', (t) => {
 
   t.deepEqual(config, {
     entry: {
-      main: ['./test.js', 'webpack/hot/only-dev-server']
+      main: ['./test.js']
     },
     devServer: {
       hot: true,
@@ -72,7 +72,7 @@ test('devServer block extends multiple entry points correctly', (t) => {
   ])
 
   t.deepEqual(config.entry, {
-    a: ['./a', 'webpack/hot/only-dev-server'],
-    b: ['./b', 'webpack/hot/only-dev-server']
+    a: ['./a'],
+    b: ['./b']
   })
 })

--- a/packages/webpack-common/src/devServer.js
+++ b/packages/webpack-common/src/devServer.js
@@ -14,7 +14,7 @@ devServer.reactHot = reactHot
  * @param {bool}   [options.historyApiFallback]
  * @param {bool}   [options.hot]
  * @param {bool}   [options.inline]
- * @param {string|string[]} [entry]   Defaults to 'webpack/hot/only-dev-server'
+ * @param {string|string[]} [entry]
  * @return {Function}
  */
 function devServer (options = {}, entry = null) {
@@ -39,11 +39,12 @@ function devServer (options = {}, entry = null) {
 function postConfig (context, config) {
   const entryPointsToAdd = context.devServer.entry.length > 0
     ? context.devServer.entry
-    : [ 'webpack/hot/only-dev-server' ]
+    : []
 
   return {
     devServer: Object.assign({
       hot: true,
+      hotOnly: true,
       historyApiFallback: true,
       inline: true
     }, context.devServer.options),

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -57,7 +57,7 @@ test('complete webpack config creation', (t) => {
     loaders: [ 'babel-loader?{"cacheDirectory":true}' ]
   })
 
-  t.deepEqual(webpackConfig.entry, { main: [ './src/main.js', 'webpack/hot/only-dev-server' ] })
+  t.deepEqual(webpackConfig.entry, { main: [ './src/main.js' ] })
 
   t.deepEqual(webpackConfig.devServer, {
     hot: true,

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -61,6 +61,7 @@ test('complete webpack config creation', (t) => {
 
   t.deepEqual(webpackConfig.devServer, {
     hot: true,
+    hotOnly: true,
     historyApiFallback: true,
     inline: true,
     proxy: {

--- a/packages/webpack2/__tests__/integration.test.js
+++ b/packages/webpack2/__tests__/integration.test.js
@@ -59,6 +59,7 @@ test('complete webpack config creation', (t) => {
 
   t.deepEqual(webpackConfig.devServer, {
     hot: true,
+    hotOnly: true,
     historyApiFallback: true,
     inline: true,
     proxy: {

--- a/packages/webpack2/__tests__/integration.test.js
+++ b/packages/webpack2/__tests__/integration.test.js
@@ -54,7 +54,7 @@ test('complete webpack config creation', (t) => {
   })
 
   t.deepEqual(webpackConfig.entry, {
-    main: [ './src/main.js', 'webpack/hot/only-dev-server' ]
+    main: [ './src/main.js' ]
   })
 
   t.deepEqual(webpackConfig.devServer, {


### PR DESCRIPTION
Hello :-)

I think that `webpack-blocks` don't need to worry about `webpack/hot/only-dev-server`, because users of `webpack-blocks` can self use `hotOnly` and `hot` options of `webpack-dev-server` (for example switch off it)

I setted options `hotOnly` by default for backwards compatibility (`hot` been setted previously)