### PR TITLE
postcss: fix loading of postcss.config.js and etc

### DIFF
--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -40,7 +40,7 @@ function postcss (plugins, options) {
         ]
       }
     },
-    plugins ? createPostcssPluginsConfig(context.webpack, plugins) : {}
+    plugins.length > 0 ? createPostcssPluginsConfig(context.webpack, plugins) : {}
   )
 }
 


### PR DESCRIPTION
Hello :-)

I found that `postcss.config.js` did't loading because `@webpack-blocks/postcss` create empty `postcss` (https://github.com/andywer/webpack-blocks/blob/master/packages/postcss/index.js#L55)