### PR TITLE
Update env function, to support more cli parameters

### DIFF
--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -59,7 +59,7 @@ function env (envName, configSetters) {
         }
     }
 
-    if (addSettings) {
+    if (!addSettings) {
         return () => ({})
     } else {
         return group(configSetters)

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -50,14 +50,14 @@ function createConfig (initialContext, configSetters) {
 function env (envName, configSetters) {
   const currentEnv = process.env.NODE_ENV || 'development'
 
-  return groupIf(currentEnv !== envName, configSetters);
+  return groupIf(currentEnv === envName, configSetters);
 }
 
 /**
  * Applies an array of webpack blocks only if condition is true
  */
 function groupIf(condition,configSetters) {
-    if (condition) {
+    if (!condition) {
         return () => ({})
     } else {
         return group(configSetters)

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -5,6 +5,7 @@ const defaultFileTypes = require('./defaultFileTypes')
 exports.createConfig = createConfig
 exports.group = group
 exports.env = env
+exports.groupIf = groupIf
 
 const isFunction = (value) => typeof value === 'function'
 
@@ -49,11 +50,18 @@ function createConfig (initialContext, configSetters) {
 function env (envName, configSetters) {
   const currentEnv = process.env.NODE_ENV || 'development'
 
-  if (currentEnv !== envName) {
-    return () => ({})
-  } else {
-    return group(configSetters)
-  }
+  return groupIf(currentEnv !== envName, configSetters);
+}
+
+/**
+ * Applies an array of webpack blocks only if condition is true
+ */
+function groupIf(condition,configSetters) {
+    if (condition) {
+        return () => ({})
+    } else {
+        return group(configSetters)
+    }
 }
 
 /**

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -5,7 +5,6 @@ const defaultFileTypes = require('./defaultFileTypes')
 exports.createConfig = createConfig
 exports.group = group
 exports.env = env
-exports.groupIf = groupIf
 
 const isFunction = (value) => typeof value === 'function'
 
@@ -48,16 +47,19 @@ function createConfig (initialContext, configSetters) {
  * @return {Function}
  */
 function env (envName, configSetters) {
-  const currentEnv = process.env.NODE_ENV || 'development'
+    let addSettings = false
+    if (typeof envName === 'string' || envName instanceof String) {
+        const currentEnv = process.env.NODE_ENV || 'development'
+        addSettings = (currentEnv === envName)
+    }
+    else {
+        for (let name in envName) {
+            if (!envName.hasOwnProperty(name)) continue
+            addSettings &= ( process.env[name] == envName[name])
+        }
+    }
 
-  return groupIf(currentEnv === envName, configSetters);
-}
-
-/**
- * Applies an array of webpack blocks only if condition is true
- */
-function groupIf(condition,configSetters) {
-    if (!condition) {
+    if (addSettings) {
         return () => ({})
     } else {
         return group(configSetters)


### PR DESCRIPTION
Hi all, thanks for the great tool!)

I feel like my case isn't much relatable, but would like to hear your feedback.
We have env function from core, and it allows us to make some parts conditional, based on NODE_ENV, but we can't share some conditional configuration among environments, can we?
For example, I wanted to add _webpack-bundle-analyzer_ to dev or build configuration, when that is explicetly required from cli... I feel that this is not right thing to do, but we can addres a question in comman.

Based on [this comment](https://github.com/webpack/webpack/issues/2254#issuecomment-203528744)
we can access custom cli parameters nativity with webpack 

If we wrap createConfig call in function that  receives cli env as argument, we can add conditions like this

`NODE_ENV=production webpack --config webpack.config.babel.js --env.analyse`

```

module.exports = (environment) => {
    environment = environment || {};
    let conditionalSetters = [];
    if (environment.analyse) {
        conditionalSetters.push(
            // partly common setters
        );
    }
    return createConfig([
        //regular config
        ...conditionalSetters
    ]);
}
```
I wasn't able to find a way to bring this arguments to env function to extent its logic, is there any? or is this a good way to go about it? 

```
module.exports = (environment) =>  createConfig([
    //regular config
    groupIf(environment.analyse,conditionalSetters)
]);

```

With best regards
