### PR TITLE
Fix tsconfig option name

### DIFF
--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -31,7 +31,7 @@ function typescript (options) {
     },
     plugins: [
       new CheckerPlugin(),
-      new TsConfigPathsPlugin({ tsconfig: options.tsconfig, compiler: options.compiler }) // This hooks into webpacks module resolution, configure via tsconfig.json
+      new TsConfigPathsPlugin({ tsconfig: options.configFileName, compiler: options.compiler }) // This hooks into webpacks module resolution, configure via tsconfig.json
     ]
   })
 


### PR DESCRIPTION
The option is called `configFileName` for the loader, but `tsconfig` for the plugin