### PR TITLE
Stop spurious usage warnings in console

### DIFF
--- a/packages/extract-text2/index.js
+++ b/packages/extract-text2/index.js
@@ -31,8 +31,8 @@ function extractText (outputFilePattern, fileType) {
             test: context.fileType(fileType),
             exclude: loaderConfig.exclude,
             loader: plugin.extract({
-              fallbackLoader: 'style-loader',
-              loader: nonStyleLoaders
+              fallback: 'style-loader',
+              use: nonStyleLoaders
             }),
             loaders: undefined
           }


### PR DESCRIPTION
Without this fix the following warnings appear in the console:

fallbackLoader option has been deprecated - replace with "fallback"
loader option has been deprecated - replace with "use"