### PR TITLE
Explicitly define default extensions

### DIFF
--- a/packages/core/lib/__tests__/createConfig.test.js
+++ b/packages/core/lib/__tests__/createConfig.test.js
@@ -27,6 +27,9 @@ test('createConfig() invokes blocks (config setters)', (t) => {
     distinct2: 'distinct2',
     distinct3: 'distinct3',
     shared: 'shared3',
+    resolve: {
+      extensions: ['.js', '.json']
+    },
     module: {
       rules: []
     },
@@ -91,6 +94,9 @@ test('createConfig() invokes post hooks', (t) => {
     distinct2: 'distinct2',
     distinct3: 'distinct3',
     shared: 'shared3',
+    resolve: {
+      extensions: ['.js', '.json']
+    },
     module: {
       rules: []
     },

--- a/packages/core/lib/index.js
+++ b/packages/core/lib/index.js
@@ -32,6 +32,10 @@ function createConfig (initialContext, configSetters) {
   const context = Object.assign({ fileType }, initialContext)
 
   const baseConfig = {
+    resolve: {
+      // Explicitly define default extensions, otherwise blocks will overwrite them instead of extending
+      extensions: ['.js', '.json']
+    },
     module: {
       rules: []
     },

--- a/packages/webpack/__tests__/devServer.integration.test.js
+++ b/packages/webpack/__tests__/devServer.integration.test.js
@@ -31,7 +31,10 @@ test('devServer() without options provides expected defaults', (t) => {
     },
     plugins: [
       new webpack.HotModuleReplacementPlugin()
-    ]
+    ],
+    resolve: {
+      extensions: ['.js', '.json']
+    }
   })
   t.true(config.plugins[0] instanceof webpack.HotModuleReplacementPlugin)
 })
@@ -64,7 +67,10 @@ test('devServer() uses custom options and can be composed', (t) => {
     },
     plugins: [
       new webpack.HotModuleReplacementPlugin()
-    ]
+    ],
+    resolve: {
+      extensions: ['.js', '.json']
+    }
   })
   t.true(config.plugins[0] instanceof webpack.HotModuleReplacementPlugin)
 })

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -130,7 +130,7 @@ test('complete webpack config creation', t => {
   t.is(webpackConfig.devtool, 'cheap-module-source-map')
 
   t.deepEqual(Object.keys(webpackConfig).sort(), [
-    'devServer', 'devtool', 'entry', 'module', 'output', 'plugins'
+    'devServer', 'devtool', 'entry', 'module', 'output', 'plugins', 'resolve'
   ])
 })
 
@@ -151,7 +151,10 @@ test('createConfig() creates a minimal configuration', t => {
       filename: 'bundle.js',
       path: path.resolve('./build')
     },
-    plugins: []
+    plugins: [],
+    resolve: {
+      extensions: ['.js', '.json']
+    }
   })
 })
 


### PR DESCRIPTION
Otherwise blocks will overwrite them instead of extending. For example I have full screen of nasty errors with `typescript` and `devSever`:

<details>

```
ERROR in multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts
Module not found: Error: Can't resolve 'webpack/hot/only-dev-server' in '/Users/sapegin/izumi/nodejs-defaults'
 @ multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts

ERROR in (webpack)-dev-server/client?http://localhost:3423
Module not found: Error: Can't resolve './socket' in '/Users/sapegin/izumi/nodejs-defaults/node_modules/webpack-dev-server/client'
 @ (webpack)-dev-server/client?http://localhost:3423 4:13-32
 @ multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts

ERROR in (webpack)-dev-server/client?http://localhost:3423
Module not found: Error: Can't resolve './overlay' in '/Users/sapegin/izumi/nodejs-defaults/node_modules/webpack-dev-server/client'
 @ (webpack)-dev-server/client?http://localhost:3423 5:14-34
 @ multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts

ERROR in (webpack)-dev-server/client?http://localhost:3423
Module not found: Error: Can't resolve 'webpack/hot/emitter' in '/Users/sapegin/izumi/nodejs-defaults/node_modules/webpack-dev-server/client'
 @ (webpack)-dev-server/client?http://localhost:3423 174:19-49
 @ multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts

ERROR in (webpack)-dev-server/client?http://localhost:3423
Module not found: Error: Can't resolve 'strip-ansi' in '/Users/sapegin/izumi/nodejs-defaults/node_modules/webpack-dev-server/client'
 @ (webpack)-dev-server/client?http://localhost:3423 3:16-37
 @ multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts

ERROR in ./~/url/url.js
Module not found: Error: Can't resolve './util' in '/Users/sapegin/izumi/nodejs-defaults/node_modules/url'
 @ ./~/url/url.js 25:11-28
 @ (webpack)-dev-server/client?http://localhost:3423
 @ multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts

ERROR in ./~/querystring-es3/index.js
Module not found: Error: Can't resolve './decode' in '/Users/sapegin/izumi/nodejs-defaults/node_modules/querystring-es3'
 @ ./~/querystring-es3/index.js 3:33-52
 @ ./~/url/url.js
 @ (webpack)-dev-server/client?http://localhost:3423
 @ multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts

ERROR in ./~/querystring-es3/index.js
Module not found: Error: Can't resolve './encode' in '/Users/sapegin/izumi/nodejs-defaults/node_modules/querystring-es3'
 @ ./~/querystring-es3/index.js 4:37-56
 @ ./~/url/url.js
 @ (webpack)-dev-server/client?http://localhost:3423
 @ multi (webpack)-dev-server/client?http://localhost:3423 webpack/hot/only-dev-server ./src/ui/app/index.ts
```

</details>