### PR TITLE
Major feature: match()

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ function myCssLoader () {
       rules: [
         Object.assign(
           {
-            test: context.fileType('text/css'),
+            test: /\.css$/,
             use: [ 'style-loader', 'my-css-loader' ]
           },
           context.match     // carries `test`, `exclude` & `include` as set by `match()`
@@ -135,7 +135,7 @@ function myCssLoader () {
 }
 ```
 
-If we use `myCssLoader` in `match()` then `context.match` will be populated with whatever we set in `match()`. Otherwise there is still the `test: context.fileType('text/css')` fallback, so our block will work without `match()` as well.
+If we use `myCssLoader` in `match()` then `context.match` will be populated with whatever we set in `match()`. Otherwise there is still the `test: /\.css$/` fallback, so our block will work without `match()` as well.
 
 Check out the [sample app](./test-app) to see a webpack config in action or read [how to create your own blocks](./docs/BLOCK-CREATION.md).
 
@@ -222,7 +222,7 @@ function babel (options = { cacheDirectory: true }) {
   return (context, util) => util.addLoader(
     Object.assign({
       // we use a `MIME type => RegExp` abstraction here in order to have consistent regexs
-      test: context.fileType('application/javascript'),
+      test: /\.(js|jsx)$/,
       exclude: /node_modules/,
       use: [
         { loader: 'babel-loader', options }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All blocks, like `babel6`, `postcss` and so on, live in their own small packages
 ```js
 const {
   createConfig,
+  match,
   webpack,
 
   // Feature blocks
@@ -61,16 +62,21 @@ const {
   sourceMaps
 } = require('webpack-blocks')
 const autoprefixer = require('autoprefixer')
+const path = require('path')
 
 module.exports = createConfig([
   entryPoint('./src/main.js'),
   setOutput('./build/bundle.js'),
-  css(),
   babel(),
-  postcss([
-    autoprefixer({ browsers: ['last 2 versions'] })
+  match('*.css', { exclude: path.resolve('node_modules') }, [
+    css(),
+    postcss([
+      autoprefixer({ browsers: ['last 2 versions'] })
+    ])
   ]),
-  file('image'),
+  match(['*.gif', '*.jpg', '*.jpeg', '*.png', '*.webp'], [
+    file()
+  ]),
   defineConstants({
     'process.env.NODE_ENV': process.env.NODE_ENV
   }),
@@ -98,7 +104,9 @@ const { css } = require('webpack-blocks')
 
 module.exports = createConfig([
   ...
-  css.modules()
+  match('*.css', { exclude: path.resolve('node_modules') }, [
+    css.modules()
+  ]
 ])
 ```
 
@@ -110,20 +118,24 @@ module.exports = createConfig([
   myCssLoader([ './styles' ])
 ])
 
-function myCssLoader (include) {
+function myCssLoader () {
   return (context, { merge }) => merge({
     module: {
       rules: [
-        {
-          test: context.fileType('text/css'),
-          use: [ 'style-loader', 'my-css-loader' ],
-          include
-        }
+        Object.assign(
+          {
+            test: context.fileType('text/css'),
+            use: [ 'style-loader', 'my-css-loader' ]
+          },
+          context.match     // carries `test`, `exclude` & `include` as set by `match()`
+        )
       ]
     }
   })
 }
 ```
+
+If we use `myCssLoader` in `match()` then `context.match` will be populated with whatever we set in `match()`. Otherwise there is still the `test: context.fileType('text/css')` fallback, so our block will work without `match()` as well.
 
 Check out the [sample app](./test-app) to see a webpack config in action or read [how to create your own blocks](./docs/BLOCK-CREATION.md).
 
@@ -206,15 +218,17 @@ Take the `babel6` webpack block for instance:
  * @param {RegExp|Function|string}  [options.exclude]   Directories to exclude.
  * @return {Function}
  */
-function babel (options) {
-  const { exclude = /\/node_modules\// } = options || {}
-
-  return (context, util) => util.addLoader({
-    // we use a `MIME type => RegExp` abstraction here in order to have consistent regexs
-    test: context.fileType('application/javascript'),
-    exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-    use: [ 'babel-loader?cacheDirectory' ]
-  })
+function babel (options = { cacheDirectory: true }) {
+  return (context, util) => util.addLoader(
+    Object.assign({
+      // we use a `MIME type => RegExp` abstraction here in order to have consistent regexs
+      test: context.fileType('application/javascript'),
+      exclude: /node_modules/,
+      use: [
+        { loader: 'babel-loader', options }
+      ]
+    }, context.match)
+  )
 }
 ```
 

--- a/docs/BLOCK-CREATION.md
+++ b/docs/BLOCK-CREATION.md
@@ -38,7 +38,7 @@ function babel (options = { cacheDirectory: true }) {
         Object.assign({
           // we use a `MIME type => RegExp` abstraction here in order to have consistent regexs
           // setting `test` & `exclude` defaults here, in case there is no `context.match` data
-          test: context.fileType('application/javascript'),
+          test: /\.(js|jsx)$/,
           exclude: /node_modules/,
           use: [
             { loader: 'babel-loader', options }
@@ -63,10 +63,12 @@ Returns an update function that adds the given loader definition to a webpack co
 
 ```js
 function sampleBlock () {
-  return (context, { addLoader }) => addLoader({
-    test: context.fileType('text/css'),
-    use: [ 'style-loader', 'css-loader' ]
-  })
+  return (context, { addLoader }) => addLoader(
+    Object.assign({
+      test: /\.css$/,
+      use: [ 'style-loader', 'css-loader' ]
+    }, context.match)
+  )
 }
 ```
 
@@ -104,6 +106,8 @@ The context object is a metadata object that is passed to every block. It is mea
 Initially it will contain the `fileType` mapping and a `webpack` instance. If you are using [hooks](#hooks) you might want to put custom metadata into the context and use it in the `post` hook.
 
 ### context.fileType
+
+*Deprecated. This feature will be removed soon. Use `match()` and `context.match` instead.*
 
 The `context.fileType` is a mapping from MIME type (`application/javascript`, `text/css`, ...) to a regular expression used for matching filenames. You can find the default file types and the extensions they match [here](https://github.com/andywer/webpack-blocks/blob/master/packages/core/lib/defaultFileTypes.js).
 

--- a/docs/BLOCK-CREATION.md
+++ b/docs/BLOCK-CREATION.md
@@ -29,32 +29,28 @@ Take the `babel6` webpack block for instance:
  * @param {RegExp|Function|string}  [options.exclude]   Directories to exclude.
  * @return {Function}
  */
-function babel (options) {
-  const { exclude = /\/node_modules\// } = options || {}
-
+function babel (options = { cacheDirectory: true }) {
   return (context, util) => prevConfig => ({
     ...prevConfig,
     module: {
       ...prevConfig.module,
       rules: prevConfig.module.rules.concat([
-        {
+        Object.assign({
           // we use a `MIME type => RegExp` abstraction here in order to have consistent regexs
+          // setting `test` & `exclude` defaults here, in case there is no `context.match` data
           test: context.fileType('application/javascript'),
-          exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-          use: [{
-            loader: 'babel-loader',
-            options: {
-              cacheDirectory: true,
-            }
-          }]
-        }
+          exclude: /node_modules/,
+          use: [
+            { loader: 'babel-loader', options }
+          ]
+        }, context.match)   // carries `test`, `exclude` & `include` as set by `match()`
       ])
     }
   })
 }
 ```
 
-Thus it is also super easy to unit test and generic enough to share it with the world.
+Thus it is also pretty easy to unit test and generic enough to share it with the world.
 
 
 ## Block Utilities
@@ -107,24 +103,25 @@ The context object is a metadata object that is passed to every block. It is mea
 
 Initially it will contain the `fileType` mapping and a `webpack` instance. If you are using [hooks](#hooks) you might want to put custom metadata into the context and use it in the `post` hook.
 
+### context.fileType
+
 The `context.fileType` is a mapping from MIME type (`application/javascript`, `text/css`, ...) to a regular expression used for matching filenames. You can find the default file types and the extensions they match [here](https://github.com/andywer/webpack-blocks/blob/master/packages/core/lib/defaultFileTypes.js).
 
+### context.match
+
+This is where the file matching patterns reside you set by using `match()` in the configuration.
+
+If the block is used within a `match()` then `context.match` will contain:
+
+* `test`: Which files to match, usually a regex or an array of regexs. Always present.
+* `exclude`: Condition(s) which paths not to match. Might not be present.
+* `include`: Condition(s) to override `exclude`. Might not be present.
+
+If the block is not used within a `match()` then `context.match` will be undefined.
+
+### context.webpack
+
 The `context.webpack` property is the webpack instance, so you do not have to `require('webpack')` in your blocks.
-
-### Adding custom file types
-
-To add a new `fileType` you can use the `fileType.add(mimeType: string, regex: RegExp)` function. See its usage in the `typescript` block:
-
-```js
-function preHook (context) {
-  const registeredTypes = context.fileType.all()
-  if (!('application/x-typescript' in registeredTypes)) {
-    context.fileType.add('application/x-typescript', /\.(ts|tsx)$/)
-  }
-}
-```
-
-Every block using MIME types that are not already defined in `core/lib/defaultFileTypes.js` needs to have a similar pre [hook](#Hooks) to register its custom types. If it is a rather common file type feel free to open a pull request for adding it to the `defaultFileTypes` as well.
 
 
 ## Hooks

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -42,21 +42,23 @@ It is also quite simple to write one. Here is a short example:
 
 ```js
 import test from 'ava'
-import { createConfig } from 'webpack-blocks'
+import { createConfig, match } from 'webpack-blocks'
 import myBlock from '../my-block'
 
-test('my block adds the loader with custom exclude', t => {
+test('my block works with match()', t => {
   const output = createConfig([
-    myBlock({ exclude: /node_modules/ })
+    match('*.myext', { exclude: /node_modules/ }, [
+      myBlock()
+    ])
   ])
 
   t.deepEqual(output, {
     module: {
       rules: [
         {
-          test: /.myext/,
+          test: /^.*\.myext/,
           exclude: /node_modules/,
-          use: 'my-fancy-loader'
+          use: [ 'my-fancy-loader' ]
         }
       ]
     }

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @webpack-blocks/assets - Changelog
+
+## Next release
+
+- Breaking API change. Use `match()` instead of passing a file type option.
+
+## 1.0.0-alpha
+
+- Initial release

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -9,64 +9,58 @@ This is the `assets` block providing configuration for the style loader, file lo
 ## Usage
 
 ```js
-const { createConfig } = require('@webpack-blocks/webpack')
+const { createConfig, match } = require('@webpack-blocks/webpack')
 const { css, file, url } = require('@webpack-blocks/assets')
 
 module.exports = createConfig([
-  css(),
-  file('application/font'),                     // will copy font files and link to them
-  url('image', { limit: 10000 })    // will load images up to 10KB as data URL
+  css(),                            // or use `match()` to apply it to other files than *.css
+  match(['*.eot', '*.ttf', '*.woff', '*.woff2'], [
+    file()                          // will copy font files to build directory and link to them
+  ]),
+  match(['*.gif', '*.jpg', '*.jpeg', '*.png', '*.svg', '*.webp'], [
+    url({ limit: 10000 })           // will load images up to 10KB as data URL
+  ])
 ])
 ```
 
 In order to use CSS modules:
 
 ```js
-const { createConfig } = require('@webpack-blocks/webpack')
+const { createConfig, match } = require('@webpack-blocks/webpack')
 const { css } = require('@webpack-blocks/assets')
 
 module.exports = createConfig([
-  css.modules({
-    exclude: [ /node_modules/ ],
-    localIdentName: '[name]--[local]--[hash:base64:5]'
-  })
+  match('*.css', { exclude: path.resolve('node_modules') }, [
+    css.modules({
+      localIdentName: '[name]--[local]--[hash:base64:5]'
+    })
+  ])
 ])
 ```
 
 
-## Generic options
+## API
 
-#### exclude *(optional)*
-Regular expression, string or function describing which files/directories to exclude from the babeling.
+### css(options: ?object)
 
-#### include *(optional)*
-Regular expression, string or function used to white-list which files/directories should be babeled. By default `exclude` is set only.
+Will match `*.css` by default if not used with `match()`. You can pass all [css-loader options](https://github.com/webpack-contrib/css-loader).
 
+### css.modules(options: ?object)
 
-## Specific usage
+Will match `*.css` by default if not used with `match()`. You can pass all [css-loader options](https://github.com/webpack-contrib/css-loader).
 
-### css(fileType: ?string, options: ?object)
-
-`fileType` defaults to `'text/css'` which matches `*.css`. You can pass all [css-loader options](https://github.com/webpack-contrib/css-loader).
-
-### css.modules(fileType: ?string, options: ?object)
-
-`fileType` defaults to `'text/css'` which matches `*.css`. You can pass all [css-loader options](https://github.com/webpack-contrib/css-loader).
-
-The difference to `css()` is that it sets the following options:
+The difference to `css()` is that it sets the following css-loader options:
 * `modules: true`
 * `importLoaders` defaults to `1`
 * `localIdentName` defaults to `'[name]--[local]--[hash:base64:5]'` in development and `'[hash:base64:10]'` in production
 
-### file(fileType: string, options: ?object)
+### file(options: ?object)
 
-The file type is supposed to be a MIME type or MIME media type like `text/css`, `image`, `image/jpeg`, ... as defined by the [default file types](https://github.com/andywer/webpack-blocks/blob/master/packages/core/lib/defaultFileTypes.js) or other blocks.
-You can pass all [file-loader options](https://github.com/webpack-contrib/file-loader) as the 2nd parameter.
+Must be used with `match()`. You can pass all [file-loader options](https://github.com/webpack-contrib/file-loader).
 
-### url(fileType: string, options: ?object)
+### url(options: ?object)
 
-The file type is supposed to be a MIME type or MIME media type like `text/css`, `image`, `image/jpeg`, ... as defined by the [default file types](https://github.com/andywer/webpack-blocks/blob/master/packages/core/lib/defaultFileTypes.js) or other blocks.
-You can pass all [url-loader options](https://github.com/webpack-contrib/url-loader). We strongly recommend setting a `limit` to prevent huge files to be encoded as a data URL.
+Must be used with `match()`. You can pass all [url-loader options](https://github.com/webpack-contrib/url-loader). We strongly recommend setting a `limit` to prevent huge files to be encoded as a data URL.
 
 
 ## Webpack blocks

--- a/packages/assets/lib/css.js
+++ b/packages/assets/lib/css.js
@@ -1,62 +1,31 @@
-const _ = require('lodash')
-
 module.exports = css
 module.exports.modules = cssModules
 
 /**
- * @param {string} [fileType]
  * @param {object} [options] You can pass all css-loader options.
- * @param {*}      [options.include]
- * @param {*}      [options.exclude]
  * @return {Function}
  * @see https://github.com/webpack-contrib/css-loader
  */
-function css (fileType = 'text/css', options) {
-  if (fileType && typeof fileType === 'object' && !options) {
-    options = fileType
-    fileType = 'text/css'
-  }
-  if (!fileType || typeof fileType !== 'string') {
-    throw new Error(`Need to pass a valid file type (MIME type) string to css().`)
-  }
-
-  options = options || {}
-
-  return (context, util) => util.addLoader({
-    test: context.fileType(fileType),
-    include: options.include,
-    exclude: options.exclude,
-    use: [
-      {
-        loader: 'style-loader'
-      },
-      {
-        loader: 'css-loader',
-        options: _.omit(options, [ 'exclude', 'include' ])
-      }
-    ]
-  })
+function css (options = {}) {
+  return (context, util) => util.addLoader(
+    Object.assign({
+      test: context.fileType('text/css'),
+      use: [
+        { loader: 'style-loader' },
+        { loader: 'css-loader', options }
+      ]
+    }, context.match)
+  )
 }
 
 /**
- * @param {string} [fileType]
  * @param {object} [options] You can pass all css-loader options.
- * @param {*}      [options.include]
- * @param {*}      [options.exclude]
  * @param {number} [options.importLoaders]    Defaults to 1.
  * @param {string} [options.localIdentName]   Defaults to '[hash:base64:10]' in production, '[name]--[local]--[hash:base64:5]' in development.
  * @return {Function}
  * @see https://github.com/webpack-contrib/css-loader
  */
-function cssModules (fileType = 'text/css', options) {
-  if (fileType && typeof fileType === 'object' && !options) {
-    options = fileType
-    fileType = 'text/css'
-  }
-  if (!fileType || typeof fileType !== 'string') {
-    throw new Error(`Need to pass a valid file type to css.modules().`)
-  }
-
+function cssModules (options = {}) {
   options = Object.assign({
     modules: true,
     importLoaders: 1,
@@ -65,18 +34,13 @@ function cssModules (fileType = 'text/css', options) {
       : '[name]--[local]--[hash:base64:5]'
   }, options)
 
-  return (context, util) => util.addLoader({
-    test: context.fileType(fileType),
-    include: options.include,
-    exclude: options.exclude,
-    use: [
-      {
-        loader: 'style-loader'
-      },
-      {
-        loader: 'css-loader',
-        options: _.omit(options, [ 'exclude', 'include' ])
-      }
-    ]
-  })
+  return (context, util) => util.addLoader(
+    Object.assign({
+      test: context.fileType('text/css'),
+      use: [
+        { loader: 'style-loader' },
+        { loader: 'css-loader', options }
+      ]
+    }, context.match)
+  )
 }

--- a/packages/assets/lib/css.js
+++ b/packages/assets/lib/css.js
@@ -9,7 +9,7 @@ module.exports.modules = cssModules
 function css (options = {}) {
   return (context, util) => util.addLoader(
     Object.assign({
-      test: context.fileType('text/css'),
+      test: /\.css$/,
       use: [
         { loader: 'style-loader' },
         { loader: 'css-loader', options }
@@ -36,7 +36,7 @@ function cssModules (options = {}) {
 
   return (context, util) => util.addLoader(
     Object.assign({
-      test: context.fileType('text/css'),
+      test: /\.css$/,
       use: [
         { loader: 'style-loader' },
         { loader: 'css-loader', options }

--- a/packages/assets/lib/file.js
+++ b/packages/assets/lib/file.js
@@ -1,28 +1,25 @@
-const _ = require('lodash')
-
 module.exports = file
 
 /**
- * @param {string} fileType
  * @param {object} [options] You can pass all file-loader options.
- * @param {*}      [options.include]
- * @param {*}      [options.exclude]
  * @return {Function}
  * @see https://github.com/webpack-contrib/file-loader
  */
-function file (fileType, options = {}) {
-  if (!fileType || typeof fileType !== 'string') {
-    throw new Error(`Need to pass a valid file type (MIME type) string to file().`)
+function file (options = {}) {
+  return (context, util) => {
+    if (!context.match) {
+      throw new Error(
+        `The file() block can only be used in combination with match(). ` +
+        `Use match() to state on which files to apply the file loader.`
+      )
+    }
+
+    return util.addLoader(
+      Object.assign({
+        use: [
+          { loader: 'file-loader', options }
+        ]
+      }, context.match)
+    )
   }
-  return (context, util) => util.addLoader({
-    test: context.fileType(fileType),
-    include: options.include,
-    exclude: options.exclude,
-    use: [
-      {
-        loader: 'file-loader',
-        options: _.omit(options, [ 'exclude', 'include' ])
-      }
-    ]
-  })
 }

--- a/packages/assets/lib/url.js
+++ b/packages/assets/lib/url.js
@@ -1,28 +1,25 @@
-const _ = require('lodash')
-
 module.exports = url
 
 /**
- * @param {string} fileType
  * @param {object} [options] You can pass all url-loader options.
- * @param {*}      [options.include]
- * @param {*}      [options.exclude]
  * @return {Function}
  * @see https://github.com/webpack-contrib/url-loader
  */
-function url (fileType, options = {}) {
-  if (!fileType || typeof fileType !== 'string') {
-    throw new Error(`Need to pass a valid file type (MIME type) string to url().`)
+function url (options = {}) {
+  return (context, util) => {
+    if (!context.match) {
+      throw new Error(
+        `The url() block can only be used in combination with match(). ` +
+        `Use match() to state on which files to apply the url loader.`
+      )
+    }
+
+    return util.addLoader(
+      Object.assign({
+        use: [
+          { loader: 'url-loader', options }
+        ]
+      }, context.match)
+    )
   }
-  return (context, util) => util.addLoader({
-    test: context.fileType(fileType),
-    include: options.include,
-    exclude: options.exclude,
-    use: [
-      {
-        loader: 'url-loader',
-        options: _.omit(options, [ 'exclude', 'include' ])
-      }
-    ]
-  })
 }

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "css-loader": "^0.28.4",
     "file-loader": "^0.11.2",
-    "lodash": "^4.17.4",
     "style-loader": "^0.18.2",
     "url-loader": "^0.5.7"
   },

--- a/packages/babel6/CHANGELOG.md
+++ b/packages/babel6/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/babel6 - Changelog
 
+## Next release
+
+- Use `match()` instead of passing an `exclude` option
+
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))

--- a/packages/babel6/README.md
+++ b/packages/babel6/README.md
@@ -19,6 +19,8 @@ module.exports = createConfig([
 ])
 ```
 
+You can also use the babel block without `match()`. It will by default match `*.js` and `*.jsx` files while excluding everything in `node_modules/`.
+
 
 ## Options
 

--- a/packages/babel6/README.md
+++ b/packages/babel6/README.md
@@ -9,22 +9,21 @@ This is the `babel6` block providing Babel (Version 6+) configuration using the 
 ## Usage
 
 ```js
-const { createConfig } = require('@webpack-blocks/webpack')
+const { createConfig, match } = require('@webpack-blocks/webpack')
 const babel = require('@webpack-blocks/babel6')
 
 module.exports = createConfig([
-  babel(/* options */)
+  match('*.js', { exclude: path.resolve('node_modules') }, [
+    babel(/* options */)
+  ])
 ])
 ```
 
 
 ## Options
 
-#### exclude *(optional)*
-Regular expression, string or function describing which files/directories to exclude from the babeling. Defaults to `/\/node_modules\//` regex, like all JS loaders.
-
-#### include *(optional)*
-Regular expression, string or function used to white-list which files/directories should be babeled. By default `exclude` is set only.
+#### cacheDirectory *(optional)*
+Uses a cache directory if set to true. Defaults to true.
 
 #### plugins *(optional)*
 Array of Babel plugins to use. Babel will read them from `.babelrc` or `package.json` if omitted.

--- a/packages/babel6/__tests__/babel6.test.js
+++ b/packages/babel6/__tests__/babel6.test.js
@@ -1,90 +1,73 @@
 import test from 'ava'
-import sinon from 'sinon'
+import { createConfig, match } from '@webpack-blocks/core'
 import babel6 from '../index'
 
-test('Babel default options work', (t) => {
-  const block = babel6()
+test('Babel default options work', t => {
+  const config = createConfig({}, [
+    babel6()
+  ])
 
-  const addLoader = sinon.spy((loaderDef) => config => config)
-  const context = {
-    fileType: () => '*.js'
-  }
-
-  t.deepEqual(block(context, { addLoader })({}), {})
-  t.deepEqual(block.post(context, { addLoader })({}), {})
-
-  t.is(addLoader.callCount, 1)
-  t.deepEqual(addLoader.lastCall.args, [
+  t.deepEqual(config.module.rules, [
     {
-      test: '*.js',
-      exclude: [ /node_modules/ ],
-      use: [ {
-        loader: 'babel-loader',
-        options: {
-          cacheDirectory: true
+      test: /\.(js|jsx)$/,
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            cacheDirectory: true
+          }
         }
-      } ]
+      ]
     }
   ])
 })
 
-test('Babel options and exclude work', (t) => {
-  const block = babel6({
-    exclude: 'foo/',
-    presets: ['es2015'],
-    plugins: ['bar']
-  })
+test('Babel options work', t => {
+  const config = createConfig({}, [
+    babel6({
+      presets: ['es2015'],
+      plugins: ['bar']
+    })
+  ])
 
-  const addLoader = sinon.spy((loaderDef) => config => config)
-  const context = {
-    fileType: () => '*.js'
-  }
-
-  t.deepEqual(block(context, { addLoader })({}), {})
-  t.deepEqual(block.post(context, { addLoader })({}), {})
-
-  t.is(addLoader.callCount, 1)
-  t.deepEqual(addLoader.lastCall.args, [
+  t.deepEqual(config.module.rules, [
     {
-      test: '*.js',
-      exclude: [ 'foo/' ],
-      use: [ {
-        loader: 'babel-loader',
-        options: {
-          cacheDirectory: true,
-          plugins: ['bar'],
-          presets: ['es2015']
+      test: /\.(js|jsx)$/,
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            cacheDirectory: true,
+            presets: ['es2015'],
+            plugins: ['bar']
+          }
         }
-      } ]
+      ]
     }
   ])
 })
 
-test('Babel `include` option works', (t) => {
-  const block = babel6({
-    exclude: null,
-    include: 'src/**/*.js'
-  })
+test('using custom match() works', t => {
+  const config = createConfig({}, [
+    match('*.js', { exclude: /node_modules/ }, [
+      babel6({
+        cacheDirectory: false
+      })
+    ])
+  ])
 
-  const addLoader = sinon.spy((loaderDef) => config => config)
-  const context = {
-    fileType: () => '*.js'
-  }
-
-  t.deepEqual(block(context, { addLoader })({}), {})
-  t.deepEqual(block.post(context, { addLoader })({}), {})
-
-  t.is(addLoader.callCount, 1)
-  t.deepEqual(addLoader.lastCall.args, [
+  t.deepEqual(config.module.rules, [
     {
-      test: '*.js',
-      include: [ 'src/**/*.js' ],
-      use: [ {
-        loader: 'babel-loader',
-        options: {
-          cacheDirectory: true
+      test: /^.*\.js$/,
+      exclude: /node_modules/,
+      use: [
+        {
+          loader: 'babel-loader',
+          options: {
+            cacheDirectory: false
+          }
         }
-      } ]
+      ]
     }
   ])
 })

--- a/packages/babel6/__tests__/babel6.test.js
+++ b/packages/babel6/__tests__/babel6.test.js
@@ -10,6 +10,7 @@ test('Babel default options work', t => {
   t.deepEqual(config.module.rules, [
     {
       test: /\.(js|jsx)$/,
+      exclude: /node_modules/,
       use: [
         {
           loader: 'babel-loader',
@@ -33,6 +34,7 @@ test('Babel options work', t => {
   t.deepEqual(config.module.rules, [
     {
       test: /\.(js|jsx)$/,
+      exclude: /node_modules/,
       use: [
         {
           loader: 'babel-loader',
@@ -49,7 +51,7 @@ test('Babel options work', t => {
 
 test('using custom match() works', t => {
   const config = createConfig({}, [
-    match('*.js', { exclude: /node_modules/ }, [
+    match('*.js', { exclude: [] }, [
       babel6({
         cacheDirectory: false
       })
@@ -59,7 +61,7 @@ test('using custom match() works', t => {
   t.deepEqual(config.module.rules, [
     {
       test: /^.*\.js$/,
-      exclude: /node_modules/,
+      exclude: [],
       use: [
         {
           loader: 'babel-loader',

--- a/packages/babel6/index.js
+++ b/packages/babel6/index.js
@@ -37,7 +37,7 @@ function babel (options = {}) {
 
 function postConfig (context, util) {
   const ruleConfig = Object.assign({
-    test: context.fileType('application/javascript'),
+    test: /\.(js|jsx)$/,
     exclude: /node_modules/,
     use: [
       { loader: 'babel-loader', options: context.babel }

--- a/packages/babel6/index.js
+++ b/packages/babel6/index.js
@@ -38,6 +38,7 @@ function babel (options = {}) {
 function postConfig (context, util) {
   const ruleConfig = Object.assign({
     test: context.fileType('application/javascript'),
+    exclude: /node_modules/,
     use: [
       { loader: 'babel-loader', options: context.babel }
     ]

--- a/packages/babel6/package.json
+++ b/packages/babel6/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Andy Wermke <andy@dev.next-step-software.com>",
   "scripts": {
-    "test": "standard && ava",
+    "test": "ava && standard",
     "prepublish": "npm test"
   },
   "engines": {
@@ -23,8 +23,8 @@
     "babel-loader": "^6.4.1"
   },
   "devDependencies": {
+    "@webpack-blocks/core": "^1.0.0-alpha",
     "ava": "^0.18.0",
-    "sinon": "^1.17.7",
     "standard": "^8.1.0"
   }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0
 
 - New block API ([#125](https://github.com/andywer/webpack-blocks/issues/125))
+- Added `match()`
 - Added `text/html` file type
 - Dropped Babel, requires node 6+
 

--- a/packages/core/lib/__tests__/match.test.js
+++ b/packages/core/lib/__tests__/match.test.js
@@ -1,0 +1,76 @@
+import test from 'ava'
+import { createConfig, match } from '../index'
+
+test('match() sets context.match', t => {
+  t.plan(9)
+
+  const matchedLoaderBlock = context => config => {
+    t.is(typeof context.match, 'object')
+    t.deepEqual(Object.keys(context.match), [ 'test' ])
+    t.true(context.match.test instanceof RegExp)
+    t.is(context.match.test.toString(), '/^.*\\.css$/')
+    return config
+  }
+  matchedLoaderBlock.pre = context => {
+    t.is(typeof context.match, 'object')
+    t.is(context.match.test.toString(), '/^.*\\.css$/')
+  }
+  matchedLoaderBlock.post = context => config => {
+    t.is(typeof context.match, 'object')
+    t.is(context.match.test.toString(), '/^.*\\.css$/')
+    return config
+  }
+
+  const unmatchedLoaderBlock = context => config => {
+    t.is(typeof context.match, 'undefined')
+    return config
+  }
+
+  createConfig({}, [
+    match('*.css', [
+      matchedLoaderBlock
+    ]),
+    unmatchedLoaderBlock
+  ])
+})
+
+test('match() supports options and extended regexps', t => {
+  t.plan(3)
+
+  const loaderBlock = context => config => {
+    t.deepEqual(Object.keys(context.match), [ 'test', 'exclude' ])
+    t.is(context.match.test.toString(), '/^(.*\\.js|.*\\.jsx)$/')
+    t.is(context.match.exclude, 'node_modules')
+    return config
+  }
+
+  // TODO: Unfortunately you may not have a space after the comma in the glob
+  //       or the space will become part of the regex...
+
+  createConfig({}, [
+    match('{*.js,*.jsx}', { exclude: 'node_modules' }, [
+      loaderBlock
+    ])
+  ])
+})
+
+test('match() returns derived context that propagates mutations', t => {
+  t.plan(1)
+
+  const mutatingBlock = context => config => {
+    context.foo = 'bar'
+    return config
+  }
+
+  const readingBlock = context => config => {
+    t.is(context.foo, 'bar')
+    return config
+  }
+
+  createConfig({}, [
+    match([ '*.sass', '*.scss' ], [
+      mutatingBlock
+    ]),
+    readingBlock
+  ])
+})

--- a/packages/core/lib/index.js
+++ b/packages/core/lib/index.js
@@ -1,3 +1,4 @@
+const globToRegex = require('glob-to-regexp')
 const createFileTypesMapping = require('./createFileTypesMapping')
 const defaultFileTypes = require('./defaultFileTypes')
 const blockUtils = require('./blockUtils')
@@ -5,6 +6,7 @@ const blockUtils = require('./blockUtils')
 exports.createConfig = createConfig
 exports.group = group
 exports.env = env
+exports.match = match
 
 const isFunction = value => typeof value === 'function'
 
@@ -83,6 +85,40 @@ function group (configSetters) {
   return Object.assign(groupBlock, { pre, post })
 }
 
+/**
+ * State on which files to apply the loader blocks passed in this call. Works
+ * like `group()`, but adds the file matching information to the context.
+ *
+ * @param {string|RegExp|Function|Array} test   A glob like `*.css` or `{*.js, *.jsx}` or something else to use as `loader.test`.
+ * @param {object} [options]                    Optional advanced matching options.
+ * @param {string|Function|RegExp|Array|object} [options.include]
+ * @param {string|Function|RegExp|Array|object} [options.exclude]
+ * @param {Function[]} configSetters            Array of functions as returned by webpack blocks.
+ * @return {Function}
+ */
+function match (test, options, configSetters) {
+  if (!configSetters && Array.isArray(options)) {
+    configSetters = options
+    options = {}
+  }
+
+  const match = { test: createFileTypeMatcher(test) }
+
+  if (options.exclude) {
+    match.exclude = options.exclude
+  }
+  if (options.include) {
+    match.include = options.include
+  }
+
+  const groupBlock = context => config => invokeConfigSetters(configSetters, deriveContextWithMatch(context, match), config)
+
+  return Object.assign(groupBlock, {
+    pre: context => invokePreHooks(configSetters, deriveContextWithMatch(context, match)),
+    post: context => config => invokePostHooks(configSetters, deriveContextWithMatch(context, match), config)
+  })
+}
+
 function getHooks (configSetters, type) {
   // Get all the blocks' pre/post hooks
   const hooks = configSetters
@@ -124,6 +160,32 @@ function invokePreHooks (configSetters, context) {
 function invokePostHooks (configSetters, context, config) {
   const postHooks = getHooks(configSetters, 'post')
   return invokeConfigSetters(postHooks, context, config)
+}
+
+function createFileTypeMatcher (test) {
+  const regexify = glob => globToRegex(glob, { extended: true })
+
+  if (typeof test === 'string') {
+    return regexify(test)
+  } else if (Array.isArray(test) && test.every(item => typeof item === 'string')) {
+    return test.map(item => regexify(item))
+  } else {
+    return test
+  }
+}
+
+function deriveContextWithMatch (context, match) {
+  // Use an ES Proxy, so the returned context will include `match` and mutations
+  // to it will also be applied to the original context. This is important,
+  // since we have now got a global context object and local ones.
+  return new Proxy(context, {
+    has (target, propName) {
+      return propName === 'match' ? true : (propName in target)
+    },
+    get (target, propName) {
+      return propName === 'match' ? match : target[propName]
+    }
+  })
 }
 
 function filterDuplicates (array) {

--- a/packages/core/lib/index.js
+++ b/packages/core/lib/index.js
@@ -30,6 +30,7 @@ function createConfig (initialContext, configSetters) {
     throw new Error(`Expected parameter 'configSetters' to be an array of functions.`)
   }
 
+  /** @deprecated context.fileType */
   const fileType = createFileTypesMapping(defaultFileTypes)
   const context = Object.assign({ fileType }, initialContext)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,7 @@
     "webpack": "^2.2.0"
   },
   "dependencies": {
+    "glob-to-regexp": "^0.3.0",
     "lodash": "^4.17.4",
     "webpack-merge": "^2.3.1"
   }

--- a/packages/dev-server/CHANGELOG.md
+++ b/packages/dev-server/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))
+- Make `reactHot` support `match()`
 - Requires node 6+
 
 ## 0.4.0

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -61,7 +61,7 @@ function postConfig (context, util) {
 function addDevEntryToAll (presentEntryPoints, devServerEntry) {
   const newEntryPoints = {}
 
-  Object.keys(presentEntryPoints).forEach((chunkName) => {
+  Object.keys(presentEntryPoints).forEach(chunkName => {
     // It's fine to just set the `devServerEntry`, instead of concat()-ing the present ones.
     // Will be concat()-ed by webpack-merge (see `createConfig()`)
     newEntryPoints[ chunkName ] = devServerEntry
@@ -84,18 +84,16 @@ function proxy (proxyRoutes) {
 }
 
 /**
- * For adding the react-hot-loader to the JS loaders. Only when using
- * react-hot-loader before version 3.
+ * For adding the react-hot-loader to the JS loaders.
  * @param {object} [options]
  * @param {RegExp, Function, string}  [options.exclude]   Directories to exclude.
  * @return {Function}
  */
-function reactHot (options = {}) {
-  const exclude = options.exclude || /\/node_modules\//
-
-  return (context, util) => util.addLoader({
-    test: context.fileType('application/javascript'),
-    exclude: Array.isArray(exclude) ? exclude : [ exclude ],
-    use: [ 'react-hot' ]
-  })
+function reactHot () {
+  return (context, util) => util.addLoader(
+    Object.assign({
+      test: context.fileType('application/javascript'),
+      use: [ 'react-hot' ]
+    }, context.match)
+  )
 }

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -92,7 +92,7 @@ function proxy (proxyRoutes) {
 function reactHot () {
   return (context, util) => util.addLoader(
     Object.assign({
-      test: context.fileType('application/javascript'),
+      test: /\.(js|jsx)$/,
       use: [ 'react-hot' ]
     }, context.match)
   )

--- a/packages/elm/CHANGELOG.md
+++ b/packages/elm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/elm - Changelog
 
+## Next release
+
+- Use `match()` instead of passing `include`/`exclude` options
+
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))

--- a/packages/elm/README.md
+++ b/packages/elm/README.md
@@ -17,14 +17,10 @@ module.exports = createConfig([
 ])
 ```
 
+You can use `match()` to customize which files to load using the elm loader.
+
 
 ## Options
-
-#### exclude *(optional)*
-Regular expression, string or function describing which files/directories to exclude from the elming. Defaults to `/\/elm-stuff\//` and `/\/node_modules\//` regex.
-
-#### include *(optional)*
-Regular expression, string or function used to white-list which files/directories should be elmed. By default `exclude` is set only.
 
 #### maxInstances *(optional)*
 Number uset to set maxInstances of elm that can spawned. This should be set to a number less than the number of cores your machine has. The ideal number is 1, as it will prevent Elm instances causing deadlocks.

--- a/packages/elm/__tests__/elm.test.js
+++ b/packages/elm/__tests__/elm.test.js
@@ -1,142 +1,79 @@
 import test from 'ava'
+import { createConfig, match } from '@webpack-blocks/core'
 import elm from '../index'
 
 test('Elm default options work', t => {
-  t.plan(1)
+  const config = createConfig({}, [
+    elm()
+  ])
 
-  const block = elm()
-  const context = {
-    fileType: () => '*.elm'
-  }
-
-  const fakeMerge = configSnippet => {
-    t.deepEqual(configSnippet.module.rules, [
-      {
-        test: '*.elm',
-        exclude: [ /elm-stuff/, /node_modules/ ],
-        use: [
-          {
-            loader: 'elm-hot-loader'
-          },
-          {
-            loader: 'elm-webpack-loader',
-            options: {
-              verbose: true,
-              warn: true,
-              debug: true
-            }
+  t.deepEqual(config.module.rules, [
+    {
+      test: /\.elm$/,
+      exclude: [ /elm-stuff/, /node_modules/ ],
+      use: [
+        {
+          loader: 'elm-hot-loader'
+        },
+        {
+          loader: 'elm-webpack-loader',
+          options: {
+            verbose: true,
+            warn: true,
+            debug: true
           }
-        ]
-      }
-    ])
-    return prevConfig => configSnippet
-  }
-
-  const intermediateConfig = block(context)({})
-  block.post(context, { merge: fakeMerge })(intermediateConfig)
+        }
+      ]
+    }
+  ])
 })
 
 test('Elm default production options work', t => {
-  t.plan(1)
+  const config = createConfig({}, [
+    elm({}, true)
+  ])
 
-  const block = elm({}, true)
-  const context = {
-    fileType: () => '*.elm'
-  }
-
-  const fakeMerge = configSnippet => {
-    t.deepEqual(configSnippet.module.rules, [
-      {
-        test: '*.elm',
-        exclude: [ /elm-stuff/, /node_modules/ ],
-        use: [
-          {
-            loader: 'elm-webpack-loader',
-            options: {}
-          }
-        ]
-      }
-    ])
-    return prevConfig => configSnippet
-  }
-
-  const intermediateConfig = block(context)({})
-  block.post(context, { merge: fakeMerge })(intermediateConfig)
+  t.deepEqual(config.module.rules, [
+    {
+      test: /\.elm$/,
+      exclude: [ /elm-stuff/, /node_modules/ ],
+      use: [
+        {
+          loader: 'elm-webpack-loader',
+          options: {}
+        }
+      ]
+    }
+  ])
 })
 
-test('Elm options and exclude work', t => {
-  t.plan(1)
-
-  const block = elm({
-    exclude: 'foo/',
-    maxInstances: 4
-  })
-  const context = {
-    fileType: () => '*.elm'
-  }
-
-  const fakeMerge = configSnippet => {
-    t.deepEqual(configSnippet.module.rules, [
-      {
-        test: '*.elm',
-        exclude: [ 'foo/' ],
-        use: [
-          {
-            loader: 'elm-hot-loader'
-          },
-          {
-            loader: 'elm-webpack-loader',
-            options: {
-              verbose: true,
-              warn: true,
-              debug: true,
-              maxInstances: 4
-            }
-          }
-        ]
-      }
+test('Elm options and custom match() work', t => {
+  const config = createConfig({}, [
+    match('*.elmfile', { exclude: 'foo/' }, [
+      elm({
+        maxInstances: 4
+      })
     ])
-    return prevConfig => configSnippet
-  }
+  ])
 
-  const intermediateConfig = block(context)({})
-  block.post(context, { merge: fakeMerge })(intermediateConfig)
-})
-
-test('Elm `include` option works', t => {
-  t.plan(1)
-
-  const block = elm({
-    exclude: null,
-    include: 'src/**/*.elm'
-  })
-  const context = {
-    fileType: () => '*.elm'
-  }
-
-  const fakeMerge = configSnippet => {
-    t.deepEqual(configSnippet.module.rules, [
-      {
-        test: '*.elm',
-        include: [ 'src/**/*.elm' ],
-        use: [
-          {
-            loader: 'elm-hot-loader'
-          },
-          {
-            loader: 'elm-webpack-loader',
-            options: {
-              verbose: true,
-              warn: true,
-              debug: true
-            }
+  t.deepEqual(config.module.rules, [
+    {
+      test: /^.*\.elmfile$/,
+      exclude: 'foo/',
+      use: [
+        {
+          loader: 'elm-hot-loader'
+        },
+        {
+          loader: 'elm-webpack-loader',
+          options: {
+            verbose: true,
+            warn: true,
+            debug: true,
+            maxInstances: 4
           }
-        ]
-      }
-    ])
-    return prevConfig => configSnippet
-  }
-
-  const intermediateConfig = block(context)({})
-  block.post(context, { merge: fakeMerge })(intermediateConfig)
+        }
+      ]
+    }
+  ])
 })

--- a/packages/elm/index.js
+++ b/packages/elm/index.js
@@ -51,7 +51,7 @@ function postConfig (context, util) {
   }
 
   const loaderConfig = Object.assign({
-    test: context.fileType('application/x-elm'),
+    test: /\.elm$/,
     exclude: [/elm-stuff/, /node_modules/],
     use: context.elm.hot ? [elmHotLoader, elmLoader] : [elmLoader]
   }, context.match)

--- a/packages/elm/package.json
+++ b/packages/elm/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Ivakhnenko Dmitry <jeetiss@ya.ru>",
   "scripts": {
-    "test": "standard && ava",
+    "test": "ava && standard",
     "prepublish": "npm test"
   },
   "engines": {
@@ -24,6 +24,7 @@
     "elm-webpack-loader": "^4.3.0"
   },
   "devDependencies": {
+    "@webpack-blocks/core": "^1.0.0-alpha",
     "ava": "^0.18.0",
     "standard": "^8.1.0"
   }

--- a/packages/extract-text/CHANGELOG.md
+++ b/packages/extract-text/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/extract-text - Changelog
 
+## Next release
+
+- Use `match()` instead of `fileType` option
+
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))

--- a/packages/extract-text/README.md
+++ b/packages/extract-text/README.md
@@ -14,7 +14,22 @@ const extractText = require('@webpack-blocks/extract-text')
 
 module.exports = createConfig([
   ...,
-  extractText('css/[name].css')   // or just `extractText()`
+  extractText('path/to/output.file')
+])
+```
+
+You will frequently want to use it to extract styles:
+
+```js
+const { createConfig, match } = require('@webpack-blocks/webpack')
+const { css } = require('@webpack-blocks/assets')
+const extractText = require('@webpack-blocks/extract-text')
+
+module.exports = createConfig([
+  match('*.css', [
+    css(),
+    extractText()     // filename defaults to 'css/[name].[contenthash:8].css'
+  ])
 ])
 ```
 

--- a/packages/extract-text/__tests__/integration.test.js
+++ b/packages/extract-text/__tests__/integration.test.js
@@ -1,0 +1,102 @@
+import test from 'ava'
+import { createConfig, match } from '@webpack-blocks/core'
+import ExtractTextPlugin from 'extract-text-webpack-plugin'
+import extractText from '../index'
+
+test('works with css() without match()', t => {
+  const config = createConfig({}, [
+    css(),
+    extractText('css/[name].css')
+  ])
+
+  const id = config.plugins[0].id
+  const plugin = Object.assign(new ExtractTextPlugin('css/[name].css'), { id })
+
+  t.deepEqual(config.plugins, [ plugin ])
+  t.deepEqual(config.module.rules, [
+    {
+      test: /\.css$/,
+      use: plugin.extract({
+        fallback: [ 'style-loader' ],
+        use: [ 'css-loader' ]
+      })
+    }
+  ])
+})
+
+test('works with css() and match()', t => {
+  const config = createConfig({}, [
+    match('*.css', { exclude: /node_modules/ }, [
+      css(),
+      extractText()
+    ])
+  ])
+
+  const id = config.plugins[0].id
+  const plugin = Object.assign(new ExtractTextPlugin('css/[name].[contenthash:8].css'), { id })
+
+  t.deepEqual(config.plugins, [ plugin ])
+  t.deepEqual(config.module.rules, [
+    {
+      test: /^.*\.css$/,
+      exclude: /node_modules/,
+      use: plugin.extract({
+        fallback: [ 'style-loader' ],
+        use: [ 'css-loader' ]
+      })
+    }
+  ])
+})
+
+test('works with sass()', t => {
+  const config = createConfig({}, [
+    match('*.scss', [
+      sass(),
+      extractText('css/styles.css')
+    ])
+  ])
+
+  const id = config.plugins[0].id
+  const plugin = Object.assign(new ExtractTextPlugin('css/styles.css'), { id })
+
+  t.deepEqual(config.plugins, [ plugin ])
+  t.deepEqual(config.module.rules, [
+    {
+      test: /^.*\.scss$/,
+      use: plugin.extract({
+        fallback: [ 'style-loader' ],
+        use: [ 'css-loader', 'sass-loader' ]
+      })
+    }
+  ])
+})
+
+test('fails properly if nothing to extract can be found', t => {
+  t.throws(() => createConfig({}, [
+    extractText()
+  ]), /No loaders found to extract contents from/)
+})
+
+test.todo('works with html()')
+
+function css () {
+  return (context, util) => util.addLoader(
+    Object.assign({
+      test: context.fileType('text/css'),
+      use: [ 'style-loader', 'css-loader' ]
+    }, context.match)
+  )
+}
+
+function sass () {
+  return (context, util) => util.addLoader(
+    Object.assign({
+      test: context.fileType('text/css'),
+      use: [
+        { loader: 'style-loader' },
+        { loader: 'css-loader' },
+        { loader: 'sass-loader' }
+      ]
+    }, context.match)
+  )
+}

--- a/packages/extract-text/__tests__/integration.test.js
+++ b/packages/extract-text/__tests__/integration.test.js
@@ -71,13 +71,34 @@ test('works with sass()', t => {
   ])
 })
 
+test('works with html()', t => {
+  const config = createConfig({}, [
+    match('*.html', [
+      html(),
+      extractText('build/layout.html')
+    ])
+  ])
+
+  const id = config.plugins[0].id
+  const plugin = Object.assign(new ExtractTextPlugin('build/layout.html'), { id })
+
+  t.deepEqual(config.plugins, [ plugin ])
+  t.deepEqual(config.module.rules, [
+    {
+      test: /^.*\.html$/,
+      use: plugin.extract({
+        fallback: [ ],
+        use: [ 'html-loader' ]
+      })
+    }
+  ])
+})
+
 test('fails properly if nothing to extract can be found', t => {
   t.throws(() => createConfig({}, [
     extractText()
   ]), /No loaders found to extract contents from/)
 })
-
-test.todo('works with html()')
 
 function css () {
   return (context, util) => util.addLoader(
@@ -97,6 +118,15 @@ function sass () {
         { loader: 'css-loader' },
         { loader: 'sass-loader' }
       ]
+    }, context.match)
+  )
+}
+
+function html () {
+  return (context, util) => util.addLoader(
+    Object.assign({
+      test: /\.html$/,
+      use: [ 'html-loader' ]
     }, context.match)
   )
 }

--- a/packages/extract-text/__tests__/integration.test.js
+++ b/packages/extract-text/__tests__/integration.test.js
@@ -103,7 +103,7 @@ test('fails properly if nothing to extract can be found', t => {
 function css () {
   return (context, util) => util.addLoader(
     Object.assign({
-      test: context.fileType('text/css'),
+      test: /\.css$/,
       use: [ 'style-loader', 'css-loader' ]
     }, context.match)
   )
@@ -112,7 +112,7 @@ function css () {
 function sass () {
   return (context, util) => util.addLoader(
     Object.assign({
-      test: context.fileType('text/css'),
+      test: /\.css$/,
       use: [
         { loader: 'style-loader' },
         { loader: 'css-loader' },

--- a/packages/extract-text/index.js
+++ b/packages/extract-text/index.js
@@ -10,95 +10,91 @@ module.exports = extractText
 
 /**
  * @param {string}    outputFilePattern
- * @param {string}  [fileType]          A MIME type used for file matching. Defaults to `text/css`.
  * @return {Function}
  */
-function extractText (outputFilePattern = 'css/[name].[contenthash:8].css', fileType = 'text/css') {
+function extractText (outputFilePattern = 'css/[name].[contenthash:8].css') {
   const plugin = new ExtractTextPlugin(outputFilePattern)
 
-  return (context, util) => prevConfig => {
-    const ruleConfig = getRuleConfigByType(context, prevConfig, fileType)
-    const nonStyleLoaders = getNonStyleLoaders(ruleConfig, fileType)
+  const postHook = (context, util) => prevConfig => {
+    let nextConfig = prevConfig
 
-    // Partial application of `addLoader`, `addPlugin` & `removeLoaders`
-    // Bind them to their job, but don't apply them on a config yet
+    // Only apply to loaders in the same `match()` group or css loaders if there is no `match()`
+    const ruleToMatch = context.match || { test: context.fileType('text/css') }
+    const matchingLoaderRules = getMatchingLoaderRules(ruleToMatch, prevConfig)
 
-    const _addLoader = util.addLoader({
-      test: context.fileType(fileType),
-      exclude: ruleConfig.exclude,
+    if (matchingLoaderRules.length === 0) {
+      throw new Error(`extractText(): No loaders found to extract contents from. Looking for loaders matching ${ruleToMatch.test}`)
+    }
+
+    const [ fallbackLoaders, nonFallbackLoaders ] = splitFallbackRule(matchingLoaderRules)
+
+    const newLoaderDef = Object.assign({}, ruleToMatch, {
       use: plugin.extract({
-        fallback: 'style-loader',
-        use: nonStyleLoaders
+        fallback: fallbackLoaders,
+        use: nonFallbackLoaders
       })
     })
-    const _addPlugin = util.addPlugin(plugin)
-    const _removeLoaders = removeLoaders(context.fileType(fileType))
 
-    // Now apply them to the config: Remove the existing loaders for that
-    // file type, add the new loader and add the plugin
+    for (const ruleToRemove of matchingLoaderRules) {
+      nextConfig = removeLoaderRule(ruleToRemove)(nextConfig)
+    }
 
-    return _addPlugin(_addLoader(_removeLoaders(prevConfig)))
+    nextConfig = util.addPlugin(plugin)(nextConfig)
+    nextConfig = util.addLoader(newLoaderDef)(nextConfig)
+
+    return nextConfig
   }
-}
 
-/**
- * @param {object}  context
- * @param {object}  webpackConfig
- * @param {string}  fileType
- * @return {object}
- * @throws {Error}
- */
-function getRuleConfigByType (context, webpackConfig, fileType) {
-  // TODO: Consider that there might be more than one loader matching the file type!
-
-  const ruleConfig = webpackConfig.module.rules.find(
-    // using string-based comparison here, since webpack-merge tends to deep-cloning things
-    (loader) => String(loader.test) === String(context.fileType(fileType))
+  return Object.assign(
+    () => prevConfig => prevConfig,
+    { post: postHook }
   )
+}
 
-  if (ruleConfig) {
-    return ruleConfig
+function getMatchingLoaderRules (ruleToMatch, webpackConfig) {
+  return webpackConfig.module.rules.filter(
+    rule => (
+      isLoaderConditionMatching(rule.test, ruleToMatch.test) &&
+      isLoaderConditionMatching(rule.exclude, ruleToMatch.exclude) &&
+      isLoaderConditionMatching(rule.include, ruleToMatch.include)
+    )
+  )
+}
+
+function splitFallbackRule (rules) {
+  const leadingStyleLoaderInAllRules = rules.every(rule => {
+    return rule.use.length > 0 && rule.use[0] && (rule.use[0] === 'style-loader' || rule.use[0].loader === 'style-loader')
+  })
+
+  if (leadingStyleLoaderInAllRules) {
+    const trimmedRules = rules.map(rule => Object.assign({}, rule, { use: rule.use.slice(1) }))
+    return [ ['style-loader'], getUseEntriesFromRules(trimmedRules) ]
   } else {
-    throw new Error(`${fileType} loader could not be found in webpack config.`)
+    return [ [], getUseEntriesFromRules(rules) ]
   }
 }
 
-/**
- * Finds the loader config for the given `fileType` and returns all loaders
- * except the `style-loader` which is expected to be the first loader.
- *
- * @param {object}  context
- * @param {object}  webpackConfig
- * @param {string}  fileType
- * @return {string[]}
- * @throws {Error}
- */
-function getNonStyleLoaders (ruleConfig, fileType) {
-  if (!ruleConfig.use || ruleConfig.use.length === 0) {
-    throw new Error(`No ${fileType} file loaders found.`)
-  }
-  const loader = typeof ruleConfig.use[0] === 'string'
-        ? ruleConfig.use[0]
-        : ruleConfig.use[0].loader
-  if (loader !== 'style-loader') {
-    throw new Error(`Expected "style-loader" to be first loader of .css files. Instead got: ${ruleConfig.use[0].loader}`)
-  }
+function getUseEntriesFromRules (rules) {
+  const normalizeUseEntry = use => typeof use === 'string' ? { loader: use } : use
 
-  // `ruleConfig.use` without the leading 'style-loader'
-  const nonStyleLoaders = [].concat(ruleConfig.use)
-  nonStyleLoaders.shift()
-
-  return nonStyleLoaders
+  return rules.reduce(
+    (useEntries, rule) => useEntries.concat(rule.use.map(normalizeUseEntry)),
+    []
+  )
 }
 
 /**
- * @param {RegExp} ruleTest   Remove all loaders that match this `.test` regex.
+ * @param {object} rule   Remove all loaders that match this loader rule.
  * @return {Function}
  */
-function removeLoaders (ruleTest) {
+function removeLoaderRule (rule) {
   return prevConfig => {
     const newRules = prevConfig.module.rules.filter(
-      ruleDef => String(ruleDef.test) !== String(ruleTest)
+      prevRule => !(
+        isLoaderConditionMatching(prevRule.test, rule.test) &&
+        isLoaderConditionMatching(prevRule.include, rule.include) &&
+        isLoaderConditionMatching(prevRule.exclude, rule.exclude)
+      )
     )
 
     return Object.assign({}, prevConfig, {
@@ -107,4 +103,30 @@ function removeLoaders (ruleTest) {
       })
     })
   }
+}
+
+function isLoaderConditionMatching (test1, test2) {
+  if (test1 === test2) {
+    return true
+  } else if (typeof test1 !== typeof test2) {
+    return false
+  } else if (test1 instanceof RegExp && test2 instanceof RegExp) {
+    return test1 === test2 || String(test1) === String(test2)
+  } else if (Array.isArray(test1) && Array.isArray(test2)) {
+    return areArraysMatching(test1, test2)
+  }
+  return false
+}
+
+function areArraysMatching (array1, array2) {
+  if (array1.length !== array2.length) {
+    return false
+  }
+
+  return array1.every(
+    item1 => (
+      array2.indexOf(item1) >= 0 ||
+      (item1 instanceof RegExp && array2.find(item2 => item2 instanceof RegExp && String(item1) === String(item2)))
+    )
+  )
 }

--- a/packages/extract-text/index.js
+++ b/packages/extract-text/index.js
@@ -19,7 +19,7 @@ function extractText (outputFilePattern = 'css/[name].[contenthash:8].css') {
     let nextConfig = prevConfig
 
     // Only apply to loaders in the same `match()` group or css loaders if there is no `match()`
-    const ruleToMatch = context.match || { test: context.fileType('text/css') }
+    const ruleToMatch = context.match || { test: /\.css$/ }
     const matchingLoaderRules = getMatchingLoaderRules(ruleToMatch, prevConfig)
 
     if (matchingLoaderRules.length === 0) {

--- a/packages/extract-text/package.json
+++ b/packages/extract-text/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Andy Wermke <andy@dev.next-step-software.com>",
   "scripts": {
-    "test": "standard",
+    "test": "ava && standard",
     "prepublish": "npm test"
   },
   "engines": {
@@ -25,6 +25,8 @@
     "webpack": "^2.2.0"
   },
   "devDependencies": {
+    "@webpack-blocks/core": "^1.0.0-alpha",
+    "ava": "^0.19.1",
     "standard": "^8.1.0",
     "webpack": "^2.2.0"
   }

--- a/packages/postcss/CHANGELOG.md
+++ b/packages/postcss/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/postcss - Changelog
 
+## Next release
+
+- Use `match()` instead of `exclude`/`include` option
+
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))

--- a/packages/postcss/README.md
+++ b/packages/postcss/README.md
@@ -9,14 +9,18 @@ This is the `postcss` block providing PostCSS configuration.
 ## Usage
 
 ```js
-const { createConfig } = require('@webpack-blocks/webpack')
+const { createConfig, match } = require('@webpack-blocks/webpack')
+const { css } = require('@webpack-blocks/assets')
 const postcss = require('@webpack-blocks/postcss')
 const autoprefixer = require('autoprefixer')
 
 module.exports = createConfig([
-  postcss([
-    autoprefixer({ browsers: ['last 2 versions'] })
-  ], { /* custom PostCSS options */ })
+  match('*.css', { exclude: path.resolve('node_modules') }, [
+    css(),
+    postcss([
+      autoprefixer({ browsers: ['last 2 versions'] })
+    ], { /* custom PostCSS options */ })
+  ])
 ])
 ```
 
@@ -24,9 +28,11 @@ Instead of passing the PostCSS plugins as an array you can also create a `postcs
 
 ```js
 // postcss.config.js
+const autoprefixer = require('autoprefixer')
+
 module.exports = {
   plugins: [
-    require('precss')
+    autoprefixer({ browsers: ['last 2 versions'] })
   ]
 }
 ```
@@ -44,15 +50,6 @@ Package name of a custom PostCSS stringifier to use.
 
 #### syntax *(optional)*
 Package name of a custom PostCSS syntax to use. The package must export a `parse` and a `stringify` function.
-
-
-### Loader options
-
-#### include *(optional)*
-If set the PostCSS loader will only be applied to the path or the paths you specified. Might be a regular expression, string, function or array of these.
-
-#### exclude *(optional)*
-If set the PostCSS loader will not be applied to these path or the paths. Might be a regular expression, string, function or array of these.
 
 
 ## Webpack blocks

--- a/packages/postcss/__tests__/integration.test.js
+++ b/packages/postcss/__tests__/integration.test.js
@@ -1,0 +1,93 @@
+import test from 'ava'
+import { css } from '@webpack-blocks/assets'
+import { createConfig, match } from '@webpack-blocks/core'
+import postcss from '../index'
+
+function LoaderOptionsPlugin (loaderOptions) {
+  this.loaderOptions = loaderOptions
+}
+
+test('Postcss works with defaults, without match()', t => {
+  const config = createConfig({}, [
+    postcss()
+  ])
+
+  t.deepEqual(config.plugins, [])
+  t.deepEqual(config.module.rules, [
+    {
+      test: /\.css$/,
+      use: [
+        'style-loader',
+        'css-loader',
+        {
+          loader: 'postcss-loader',
+          options: {}
+        }
+      ]
+    }
+  ])
+})
+
+test('Postcss works with css() & match()', t => {
+  const config = createConfig({}, [
+    match('*.css', { exclude: /node_modules/ }, [
+      css(),
+      postcss()
+    ])
+  ])
+
+  t.deepEqual(config.plugins, [])
+  t.deepEqual(config.module.rules, [
+    {
+      test: /^.*\.css$/,
+      exclude: /node_modules/,
+      use: [
+        'style-loader',
+        {
+          loader: 'css-loader',
+          options: {}
+        },
+        {
+          loader: 'postcss-loader',
+          options: {}
+        }
+      ]
+    }
+  ])
+})
+
+test('Postcss allows inline plugin config and custom options', t => {
+  const fakePostcssPlugin = { id: 'fakePostcssPlugin' }
+
+  const config = createConfig({ webpack: { LoaderOptionsPlugin } }, [
+    match('*.css', [
+      postcss([
+        fakePostcssPlugin
+      ], { parser: 'sugarss' })
+    ])
+  ])
+
+  t.deepEqual(config.plugins, [
+    new LoaderOptionsPlugin({
+      options: {
+        postcss: [ fakePostcssPlugin ],
+        context: '/'
+      }
+    })
+  ])
+  t.deepEqual(config.module.rules, [
+    {
+      test: /^.*\.css$/,
+      use: [
+        'style-loader',
+        'css-loader',
+        {
+          loader: 'postcss-loader',
+          options: {
+            parser: 'sugarss'
+          }
+        }
+      ]
+    }
+  ])
+})

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -17,7 +17,7 @@ module.exports = postcss
 function postcss (plugins = [], options = {}) {
   return (context, util) => prevConfig => {
     const ruleDef = Object.assign({
-      test: context.fileType('text/css'),
+      test: /\.css$/,
       use: [
         'style-loader',
         'css-loader',

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "author": "Andy Wermke <andy@dev.next-step-software.com>",
   "scripts": {
-    "test": "standard",
+    "test": "ava && standard",
     "prepublish": "npm test"
   },
   "engines": {
@@ -22,6 +22,9 @@
     "postcss-loader": "^1.2.0"
   },
   "devDependencies": {
+    "@webpack-blocks/assets": "^1.0.0-alpha",
+    "@webpack-blocks/core": "^1.0.0-alpha",
+    "ava": "^0.19.1",
     "standard": "^8.1.0"
   }
 }

--- a/packages/sass/CHANGELOG.md
+++ b/packages/sass/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/sass - Changelog
 
+## Next release
+
+- Make compatible with `match()`
+
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))

--- a/packages/sass/README.md
+++ b/packages/sass/README.md
@@ -17,6 +17,20 @@ module.exports = createConfig([
 ])
 ```
 
+Use `match()` to explicitly specify on which files to apply the block:
+
+```js
+const { createConfig, match } = require('@webpack-blocks/webpack')
+const sass = require('@webpack-blocks/sass')
+
+module.exports = createConfig([
+  match('*.scss', { exclude: path.resolve('node_modules') }, [
+    sass(/* node-sass options */)
+  ])
+])
+```
+
+
 ## Options
 
 You can pass random `sass-loader` options as an object to the `sass` block. Those options are basically identical with [node-sass' options](https://github.com/sass/node-sass#options).
@@ -28,8 +42,10 @@ You can use the `extract-text` block to extract the compiled SASS/SCSS styles in
 
 ```js
 module.exports = createConfig([
-  sass(),
-  extractText('css/[name].css', 'text/x-sass')
+  match('*.scss', [
+    sass(),
+    extractText('css/[name].css')
+  ])
 ])
 ```
 

--- a/packages/sass/index.js
+++ b/packages/sass/index.js
@@ -15,20 +15,22 @@ module.exports = sass
  * @return {Function}
  */
 function sass (options = {}) {
-  return (context, util) => util.addLoader({
-    test: context.fileType('text/x-sass'),
-    use: [
-      'style-loader',
-      {
-        loader: 'css-loader',
-        options: {
-          sourceMap: !!options.sourceMap
+  return (context, util) => util.addLoader(
+    Object.assign({
+      test: context.fileType('text/x-sass'),
+      use: [
+        'style-loader',
+        {
+          loader: 'css-loader',
+          options: {
+            sourceMap: Boolean(options.sourceMap)
+          }
+        },
+        {
+          loader: 'sass-loader',
+          options
         }
-      },
-      {
-        loader: 'sass-loader',
-        options
-      }
-    ]
-  })
+      ]
+    }, context.match)
+  )
 }

--- a/packages/sass/index.js
+++ b/packages/sass/index.js
@@ -17,7 +17,7 @@ module.exports = sass
 function sass (options = {}) {
   return (context, util) => util.addLoader(
     Object.assign({
-      test: context.fileType('text/x-sass'),
+      test: /\.(sass|scss)$/,
       use: [
         'style-loader',
         {

--- a/packages/tslint/CHANGELOG.md
+++ b/packages/tslint/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/tslint - Changelog
 
+## Next release
+
+- Make compatible with `match()`
+
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))

--- a/packages/tslint/README.md
+++ b/packages/tslint/README.md
@@ -17,6 +17,9 @@ module.exports = createConfig([
 ])
 ```
 
+Use `match()` to explicitly specify the files to lint.
+
+
 ## Options
 
 You can pass random `ts-loader` options as an object to the `tslint` block. See [tslint-loader options](https://github.com/wbuchwalter/tslint-loader#usage).

--- a/packages/tslint/index.js
+++ b/packages/tslint/index.js
@@ -14,7 +14,7 @@ function tslint (options = {}) {
   return (context, util) => prevConfig => {
     let nextConfig = util.addLoader(
       Object.assign({
-        test: context.fileType('application/x-typescript'),
+        test: /\.(ts|tsx)$/,
         use: [ 'tslint-loader' ],
         enforce: 'pre'
       }, context.match)

--- a/packages/tslint/index.js
+++ b/packages/tslint/index.js
@@ -11,30 +11,23 @@ module.exports = tslint
  * @return {Function}
  */
 function tslint (options = {}) {
-  const setter = (context, util) => prevConfig => {
-    const _addLoader = util.addLoader({
-      test: context.fileType('application/x-typescript'),
-      use: [ 'tslint-loader' ],
-      enforce: 'pre'
-    })
-    const _addPlugin = util.addPlugin(
+  return (context, util) => prevConfig => {
+    let nextConfig = util.addLoader(
+      Object.assign({
+        test: context.fileType('application/x-typescript'),
+        use: [ 'tslint-loader' ],
+        enforce: 'pre'
+      }, context.match)
+    )(prevConfig)
+
+    nextConfig = util.addPlugin(
       new context.webpack.LoaderOptionsPlugin({
         options: {
           tslint: options
         }
       })
-    )
+    )(nextConfig)
 
-    return _addLoader(_addPlugin(prevConfig))
-  }
-
-  return Object.assign(setter, { pre })
-}
-
-function pre (context) {
-  const registeredTypes = context.fileType.all()
-
-  if (!('application/x-typescript' in registeredTypes)) {
-    context.fileType.add('application/x-typescript', /\.(ts|tsx)$/)
+    return nextConfig
   }
 }

--- a/packages/typescript/CHANGELOG.md
+++ b/packages/typescript/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/typescript - Changelog
 
+## Next release
+
+- Make compatible with `match()`
+
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -17,6 +17,9 @@ module.exports = createConfig([
 ])
 ```
 
+Use `match()` to explicitly specify the files to load using the TypeScript loader.
+
+
 ## Options
 
 Uses the default tsconfig.json in the root directory to pass options (See [here](https://github.com/s-panferov/awesome-typescript-loader#tsconfigjson))

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -4,8 +4,7 @@
  * @see https://github.com/s-panferov/awesome-typescript-loader
  */
 
-const CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin
-const TsConfigPathsPlugin = require('awesome-typescript-loader').TsConfigPathsPlugin
+const { CheckerPlugin, TsConfigPathsPlugin } = require('awesome-typescript-loader')
 
 module.exports = typescript
 
@@ -20,7 +19,7 @@ function typescript (options = {}) {
     },
     module: {
       rules: [
-        {
+        Object.assign({
           test: context.fileType('application/x-typescript'),
           use: [
             {
@@ -28,7 +27,7 @@ function typescript (options = {}) {
               options
             }
           ]
-        }
+        }, context.match)
       ]
     },
     plugins: [

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -20,7 +20,7 @@ function typescript (options = {}) {
     module: {
       rules: [
         Object.assign({
-          test: context.fileType('application/x-typescript'),
+          test: /\.(ts|tsx)$/,
           use: [
             {
               loader: 'awesome-typescript-loader',

--- a/packages/webpack-blocks/README.md
+++ b/packages/webpack-blocks/README.md
@@ -21,6 +21,7 @@ const {
   defineConstants,
   entryPoint,
   extractText,
+  match,
   setOutput,
   webpack
 } = require('webpack-blocks')
@@ -29,11 +30,13 @@ module.exports = createConfig([
   entryPoint('./src/main.js'),
   setOutput('./build/bundle.js'),
   babel(),
-  css(),
   defineConstants({
     'process.env.NODE_ENV': process.env.NODE_ENV
   }),
-  extractText('css/[name].css'),
+  match('*.css', { exclude: /node_modules/ }, [
+    css(),
+    extractText('css/[name].css')
+  ]),
   addPlugins([
     new webpack.LoaderOptionsPlugin({ minimize: true })
   ])

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -1,9 +1,13 @@
 # @webpack-blocks/webpack - Changelog
 
+## Next release
+
+- Added `match()`
+- Added `resolve()`, deprecate `resolveAliases()`
+
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))
-- Added `match()`
 - Fail with meaningful message if `createConfig()` is called with invalid param ([#110](https://github.com/andywer/webpack-blocks/issues/110))
 - Added `text/html` file type (in `@webpack-blocks/core`)
 - Requires node 6+

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0
 
 - Updated for new core API ([#125](https://github.com/andywer/webpack-blocks/issues/125))
+- Added `match()`
 - Fail with meaningful message if `createConfig()` is called with invalid param ([#110](https://github.com/andywer/webpack-blocks/issues/110))
 - Added `text/html` file type (in `@webpack-blocks/core`)
 - Requires node 6+

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -49,7 +49,7 @@ Applies an array of webpack blocks only if `process.env.NODE_ENV` matches the gi
 
 #### match(test: string|RegExp|Array, options: ?object, configSetters: Function[]): Function
 
-State on which files to apply the loader blocks passed in this call. Works like `group()`, but adds the file matching information to the context. The options parameter is optional.
+State on which files to apply the loader blocks passed in this call. Works like `group()`, but adds the file matching information to the context that can be used by the child blocks. The options parameter is optional.
 
 Use like this:
 
@@ -58,6 +58,16 @@ module.exports = createConfig([
   match('*.scss', { exclude: path.resolve('node_modules') }, [
     sass(),
     extractText('css/[name].css')
+  ])
+])
+```
+
+To match multiple file patterns you can pass a pattern array:
+
+```js
+module.exports = createConfig([
+  match(['*.sass', '*.scss'], [
+    /* blocks */
   ])
 ])
 ```

--- a/packages/webpack/README.md
+++ b/packages/webpack/README.md
@@ -47,6 +47,21 @@ Combines an array of blocks to a new joined block. Running this single block has
 
 Applies an array of webpack blocks only if `process.env.NODE_ENV` matches the given `envName`. If no `NODE_ENV` is set, it will be treated as 'development'.
 
+#### match(test: string|RegExp|Array, options: ?object, configSetters: Function[]): Function
+
+State on which files to apply the loader blocks passed in this call. Works like `group()`, but adds the file matching information to the context. The options parameter is optional.
+
+Use like this:
+
+```js
+module.exports = createConfig([
+  match('*.scss', { exclude: path.resolve('node_modules') }, [
+    sass(),
+    extractText('css/[name].css')
+  ])
+])
+```
+
 #### defineConstants(constants: object): Function
 
 Replaces constants in your source code with a value (`process.env.NODE_ENV` for example) using the [webpack.DefinePlugin](https://webpack.github.io/docs/list-of-plugins.html#defineplugin). Pass an object containing your constant definitions: `{ [constantName: string]: <constantValue: any> }`.

--- a/packages/webpack/__e2e-fixtures__/babel-postcss-extract-text/webpack.config.js
+++ b/packages/webpack/__e2e-fixtures__/babel-postcss-extract-text/webpack.config.js
@@ -1,11 +1,11 @@
-const webpack = require('../../index')
-
-// Need to write it like this instead of destructuring so it runs on Node 4.x w/o transpiling
-const createConfig = webpack.createConfig
-const defineConstants = webpack.defineConstants
-const entryPoint = webpack.entryPoint
-const performance = webpack.performance
-const setOutput = webpack.setOutput
+const {
+  createConfig,
+  defineConstants,
+  entryPoint,
+  match,
+  performance,
+  setOutput
+} = require('../../index')
 
 const babel = require('@webpack-blocks/babel6')
 const postcss = require('@webpack-blocks/postcss')
@@ -21,12 +21,14 @@ module.exports = createConfig([
     path.join(__dirname, 'build/bundle.js')
   ),
   babel(),
-  postcss([
-    precss
+  match('*.css', [
+    postcss([
+      precss
+    ]),
+    extractText(
+      'styles.css'
+    )
   ]),
-  extractText(
-    'styles.css'
-  ),
   performance({
     maxAssetSize: 100000,
     maxEntrypointSize: 500000,

--- a/packages/webpack/__e2e-fixtures__/elm/webpack.config.js
+++ b/packages/webpack/__e2e-fixtures__/elm/webpack.config.js
@@ -1,10 +1,4 @@
-const webpack2 = require('../../index')
-
-// Need to write it like this instead of destructuring so it runs on Node 4.x w/o transpiling
-const createConfig = webpack2.createConfig
-const entryPoint = webpack2.entryPoint
-const performance = webpack2.performance
-const setOutput = webpack2.setOutput
+const { createConfig, entryPoint, performance, setOutput } = require('../../index')
 
 const elm = require('@webpack-blocks/elm')
 const path = require('path')

--- a/packages/webpack/__e2e-fixtures__/minimal/webpack.config.js
+++ b/packages/webpack/__e2e-fixtures__/minimal/webpack.config.js
@@ -1,10 +1,4 @@
-const webpack = require('../../index')
-
-// Need to write it like this instead of destructuring so it runs on Node 4.x w/o transpiling
-const createConfig = webpack.createConfig
-const customConfig = webpack.customConfig
-const entryPoint = webpack.entryPoint
-const setOutput = webpack.setOutput
+const { createConfig, customConfig, entryPoint, setOutput } = require('../../index')
 
 const path = require('path')
 

--- a/packages/webpack/__e2e-fixtures__/postcss-sass-sourcemaps/webpack.config.js
+++ b/packages/webpack/__e2e-fixtures__/postcss-sass-sourcemaps/webpack.config.js
@@ -1,9 +1,4 @@
-const webpackBlock = require('../../index')
-
-// Need to write it like this instead of destructuring so it runs on Node 4.x w/o transpiling
-const createConfig = webpackBlock.createConfig
-const entryPoint = webpackBlock.entryPoint
-const setOutput = webpackBlock.setOutput
+const { createConfig, entryPoint, setOutput } = require('../../index')
 
 const path = require('path')
 const postcss = require('@webpack-blocks/postcss')

--- a/packages/webpack/__e2e-fixtures__/sass-extract-text/webpack.config.js
+++ b/packages/webpack/__e2e-fixtures__/sass-extract-text/webpack.config.js
@@ -1,9 +1,4 @@
-const webpackBlock = require('../../index')
-
-// Need to write it like this instead of destructuring so it runs on Node 4.x w/o transpiling
-const createConfig = webpackBlock.createConfig
-const entryPoint = webpackBlock.entryPoint
-const setOutput = webpackBlock.setOutput
+const { createConfig, entryPoint, match, setOutput } = require('../../index')
 
 const path = require('path')
 const extractText = require('@webpack-blocks/extract-text')
@@ -16,6 +11,8 @@ module.exports = createConfig([
   setOutput(
     path.join(__dirname, 'build/bundle.js')
   ),
-  sass({ indentSyntax: true }),
-  extractText('styles.css', 'text/x-sass')
+  match('*.sass', [
+    sass({ indentSyntax: true }),
+    extractText('styles.css')
+  ])
 ])

--- a/packages/webpack/__e2e-fixtures__/typescript/webpack.config.js
+++ b/packages/webpack/__e2e-fixtures__/typescript/webpack.config.js
@@ -1,11 +1,4 @@
-const webpack = require('../../index')
-
-// Need to write it like this instead of destructuring so it runs on Node 4.x w/o transpiling
-const defineConstants = webpack.defineConstants
-const createConfig = webpack.createConfig
-const entryPoint = webpack.entryPoint
-const performance = webpack.performance
-const setOutput = webpack.setOutput
+const { createConfig, defineConstants, entryPoint, performance, setOutput } = require('../../index')
 
 const typescript = require('@webpack-blocks/typescript')
 const tslint = require('@webpack-blocks/tslint')

--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -4,6 +4,7 @@ import { createConfig, entryPoint, match, setOutput, sourceMaps } from '../index
 import { css, file, url } from '@webpack-blocks/assets'
 import babel from '@webpack-blocks/babel6'
 import devServer from '@webpack-blocks/dev-server'
+import postcss from '@webpack-blocks/postcss'
 import sass from '@webpack-blocks/sass'
 
 test('complete webpack config creation', t => {
@@ -23,6 +24,7 @@ test('complete webpack config creation', t => {
       css.modules({
         localIdentName: '[name]--[local]--[hash:base64:5]'
       }),
+      postcss(),
       sass()
     ]),
     match(images, { exclude: /node_modules/ }, [
@@ -48,6 +50,10 @@ test('complete webpack config creation', t => {
           modules: true,
           sourceMap: false
         }
+      },
+      {
+        loader: 'postcss-loader',
+        options: {}
       },
       {
         loader: 'sass-loader',

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -14,6 +14,7 @@ const webpackVersion = parseVersion(require('webpack/package.json').version)
 
 exports.env = core.env
 exports.group = core.group
+exports.match = core.match
 exports.webpack = webpack
 
 exports.createConfig = createConfig

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "Andy Wermke <andy@dev.next-step-software.com>",
   "scripts": {
-    "test": "standard && ava",
+    "test": "ava && standard",
     "prepublish": "npm test"
   },
   "engines": {

--- a/test-app/webpack.config.babel.js
+++ b/test-app/webpack.config.babel.js
@@ -22,7 +22,7 @@ const {
 
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 
-const development = () => group([
+const developmentConfig = () => group([
   sourceMaps(),
   devServer(),
   devServer.proxy({
@@ -35,7 +35,7 @@ const development = () => group([
   })
 ])
 
-const production = () => group([
+const productionConfig = () => group([
   extractText(),
   addPlugins([
     new webpack.LoaderOptionsPlugin({
@@ -56,10 +56,9 @@ const production = () => group([
 ])
 
 module.exports = createConfig([
-  setOutput('./build/bundle.js'),
   babel(),
-  css.modules(),
   typescript(),
+  css.modules(),
   addPlugins([
     new HtmlWebpackPlugin({
       inject: true,
@@ -71,10 +70,11 @@ module.exports = createConfig([
   }),
   env('development', [
     entryPoint('./src/index.dev.js'),
-    development()
+    developmentConfig()
   ]),
   env('production', [
     entryPoint('./src/index.js'),
-    production()
+    setOutput('./build/bundle.js'),
+    productionConfig()
   ])
 ])


### PR DESCRIPTION
This is quite a big pull request (sorry!), but it comes with a bunch of neat improvements, I think:

* Introduces `match()` to get rid of inconsistent `exclude`/`include` options in blocks
* API of most blocks didn't change or just dropped `exclude`/`include` options
* API of `@webpack-blocks/assets` (`css()`, `file()` & `url()` block) changed noticeably
* Docs have been updated

Needed to touch all blocks for this (😱), but I used this opportunity to improve the block tests a bit and add a few new tests. Also cleaned up some nasty code bits.

Please have a look, do a quick check of the changed code and read the updated docs if you can find some time. I would like to publish this as `1.0.0-beta`.

Shout if you disagree with something, I was out on a limb here 😉