### PR TITLE
Fix resolve block to prefer custom extensions over defaults

### DIFF
--- a/packages/webpack/__tests__/integration.test.js
+++ b/packages/webpack/__tests__/integration.test.js
@@ -1,6 +1,6 @@
 import test from 'ava'
 import path from 'path'
-import { createConfig, entryPoint, match, setOutput, sourceMaps } from '../index'
+import { createConfig, entryPoint, match, setOutput, sourceMaps, resolve } from '../index'
 import { css, file, url } from '@webpack-blocks/assets'
 import babel from '@webpack-blocks/babel6'
 import devServer from '@webpack-blocks/dev-server'
@@ -176,4 +176,16 @@ test('context contains necessary properties', t => {
       return prevConfig => prevConfig
     }
   ])
+})
+
+test('prepends custom extension to default ones', t => {
+  const expectedExtensionOrder = ['.custom.js', '.js', '.json']
+
+  const webpackConfig = createConfig([
+    resolve({ extensions: ['.custom.js'] })
+  ])
+
+  const actualExtensions = webpackConfig.resolve.extensions
+
+  t.deepEqual(actualExtensions, expectedExtensionOrder)
 })

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -7,6 +7,7 @@
 const assert = require('assert-plus')
 const core = require('@webpack-blocks/core')
 const webpack = require('webpack')
+const webpackMerge = require('webpack-merge')
 const path = require('path')
 const parseVersion = require('./lib/parseVersion')
 
@@ -116,7 +117,10 @@ function performance (performanceBudget) {
  * @see https://webpack.js.org/configuration/resolve/
  */
 function resolve (config) {
-  return (context, util) => util.merge({
+  const strategy = { 'resolve.extensions': 'prepend' }
+  const merge = webpackMerge.smartStrategy(strategy)
+
+  return () => prevConfig => merge(prevConfig, {
     resolve: config
   })
 }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -19,7 +19,8 @@
   "bugs": "https://github.com/andywer/webpack-blocks/issues",
   "dependencies": {
     "@webpack-blocks/core": "^1.0.0-beta",
-    "assert-plus": "^1.0.0"
+    "assert-plus": "^1.0.0",
+    "webpack-merge": "^4.1.0"
   },
   "devDependencies": {
     "@webpack-blocks/assets": "^1.0.0-beta",


### PR DESCRIPTION
Allow custom extensions configurations, like
```js
resolve({
  extensions: ['.custom.js']
})
```
so that 
```js 
import foo from './foo'
```
first checks `./foo.custom.js` before falling back to `./foo.js`

Closes #176 
