### PR TITLE
Change match() to pass all webpack rule options to context.

### DIFF
--- a/packages/babel/__tests__/babel.test.js
+++ b/packages/babel/__tests__/babel.test.js
@@ -51,7 +51,7 @@ test('Babel options work', t => {
 
 test('using custom match() works', t => {
   const config = createConfig({}, [
-    match('*.js', { exclude: [] }, [
+    match('*.js', { exclude: null }, [
       babel({
         cacheDirectory: false
       })
@@ -61,7 +61,7 @@ test('using custom match() works', t => {
   t.deepEqual(config.module.rules, [
     {
       test: /^.*\.js$/,
-      exclude: [],
+      exclude: null,
       use: [
         {
           loader: 'babel-loader',

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @webpack-blocks/core - Changelog
 
+## master
+
+- Change `match()` to passes all [webpack rule options](https://webpack.js.org/configuration/module/) to context. ([#250](https://github.com/andywer/webpack-blocks/pull/250))
+
 ## 1.0.0-beta.2
 
 - More useful error message when passing invalid blocks to `createConfig()` ([#171](https://github.com/andywer/webpack-blocks/issues/171))

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,8 +1,8 @@
 # @webpack-blocks/core - Changelog
 
-## master
+## Next version
 
-- Change `match()` to passes all [webpack rule options](https://webpack.js.org/configuration/module/) to context. ([#250](https://github.com/andywer/webpack-blocks/pull/250))
+- Change `match()` to pass all [webpack rule options](https://webpack.js.org/configuration/module/) to context. ([#250](https://github.com/andywer/webpack-blocks/pull/250))
 
 ## 1.0.0-beta.2
 

--- a/packages/core/lib/__tests__/match.test.js
+++ b/packages/core/lib/__tests__/match.test.js
@@ -35,7 +35,7 @@ test('match() sets context.match', t => {
 
 test('match() supports options and extended regexps', t => {
   const loaderBlock = context => config => {
-    t.deepEqual(Object.keys(context.match).sort(), [ 'exclude', 'test' ])
+    t.deepEqual(Object.keys(context.match).sort(), [ 'enforce', 'exclude', 'test' ])
     t.is(context.match.test.toString(), '/^.*\\.(js|jsx)$/')
     t.is(context.match.exclude, 'node_modules')
     return config
@@ -45,7 +45,7 @@ test('match() supports options and extended regexps', t => {
   //       or the space will become part of the regex...
 
   createConfig({}, [
-    match('*.{js,jsx}', { exclude: 'node_modules' }, [
+    match('*.{js,jsx}', { exclude: 'node_modules', enforce: 'pre' }, [
       loaderBlock
     ])
   ])

--- a/packages/core/lib/__tests__/match.test.js
+++ b/packages/core/lib/__tests__/match.test.js
@@ -39,8 +39,8 @@ test('match() supports options and extended regexps', t => {
   t.plan(3)
 
   const loaderBlock = context => config => {
-    t.deepEqual(Object.keys(context.match), [ 'test', 'exclude' ])
-    t.is(context.match.test.toString(), '/^(.*\\.js|.*\\.jsx)$/')
+    t.deepEqual(Object.keys(context.match), [ 'exclude', 'test' ])
+    t.is(context.match.test.toString(), '/^.*\\.(js|jsx)$/')
     t.is(context.match.exclude, 'node_modules')
     return config
   }
@@ -49,7 +49,7 @@ test('match() supports options and extended regexps', t => {
   //       or the space will become part of the regex...
 
   createConfig({}, [
-    match('{*.js,*.jsx}', { exclude: 'node_modules' }, [
+    match('*.{js,jsx}', { exclude: 'node_modules' }, [
       loaderBlock
     ])
   ])

--- a/packages/core/lib/__tests__/match.test.js
+++ b/packages/core/lib/__tests__/match.test.js
@@ -3,8 +3,6 @@ import createConfig from '../createConfig'
 import match from '../match'
 
 test('match() sets context.match', t => {
-  t.plan(9)
-
   const matchedLoaderBlock = context => config => {
     t.is(typeof context.match, 'object')
     t.deepEqual(Object.keys(context.match), [ 'test' ])
@@ -36,8 +34,6 @@ test('match() sets context.match', t => {
 })
 
 test('match() supports options and extended regexps', t => {
-  t.plan(3)
-
   const loaderBlock = context => config => {
     t.deepEqual(Object.keys(context.match).sort(), [ 'exclude', 'test' ])
     t.is(context.match.test.toString(), '/^.*\\.(js|jsx)$/')
@@ -56,8 +52,6 @@ test('match() supports options and extended regexps', t => {
 })
 
 test('match() supports negations', t => {
-  t.plan(3)
-
   const loaderBlock = context => config => {
     t.deepEqual(Object.keys(context.match).sort(), [ 'exclude', 'test' ])
     t.is(context.match.test.toString(), '/^.*\\.js$/')
@@ -73,8 +67,6 @@ test('match() supports negations', t => {
 })
 
 test('match() returns derived context that propagates mutations', t => {
-  t.plan(1)
-
   const mutatingBlock = context => config => {
     context.foo = 'bar'
     return config
@@ -91,4 +83,10 @@ test('match() returns derived context that propagates mutations', t => {
     ]),
     readingBlock
   ])
+})
+
+test('match() throws if `options` argument has `test`', t => {
+  t.throws(() => createConfig({}, [
+    match(['*.js'], {test: /\.jsx/}, [])
+  ]))
 })

--- a/packages/core/lib/match.js
+++ b/packages/core/lib/match.js
@@ -10,8 +10,6 @@ module.exports = match
  *
  * @param {string|RegExp|Function|Array} test   A glob like `*.css` or `{*.js, *.jsx}` or something else to use as `loader.test`.
  * @param {object} [options]                    Optional advanced matching options.
- * @param {string|Function|RegExp|Array|object} [options.include]
- * @param {string|Function|RegExp|Array|object} [options.exclude]
  * @param {Function[]} configSetters            Array of functions as returned by webpack blocks.
  * @return {Function}
  */
@@ -23,20 +21,13 @@ function match (test, options, configSetters) {
 
   assertConfigSetters(configSetters)
 
-  const match = { test: createFileTypeMatcher(test) }
+  options.test = createFileTypeMatcher(test)
 
-  if (options.exclude) {
-    match.exclude = options.exclude
-  }
-  if (options.include) {
-    match.include = options.include
-  }
-
-  const groupBlock = context => config => invokeConfigSetters(configSetters, deriveContextWithMatch(context, match), config)
+  const groupBlock = context => config => invokeConfigSetters(configSetters, deriveContextWithMatch(context, options), config)
 
   return Object.assign(groupBlock, {
-    pre: context => invokePreHooks(configSetters, deriveContextWithMatch(context, match)),
-    post: context => config => invokePostHooks(configSetters, deriveContextWithMatch(context, match), config)
+    pre: context => invokePreHooks(configSetters, deriveContextWithMatch(context, options)),
+    post: context => config => invokePostHooks(configSetters, deriveContextWithMatch(context, options), config)
   })
 }
 

--- a/packages/core/lib/match.js
+++ b/packages/core/lib/match.js
@@ -27,7 +27,7 @@ function match (test, options, configSetters) {
   assertConfigSetters(configSetters)
 
   if (options.test) {
-    throw new Error(`match(): Setting 'test' in options is not supported and will be overriden with a 'test' argument.`)
+    throw new Error(`match(): Setting 'test' in options is not supported; use the argument instead.`)
   }
 
   const { inclusions, exclusions } = splitPatterns(toArray(test))

--- a/packages/core/lib/match.js
+++ b/packages/core/lib/match.js
@@ -9,7 +9,7 @@ module.exports = match
  * like `group()`, but adds the file matching information to the context.
  *
  * @param {string|RegExp|Function|Array} test   A glob like `*.css` or `{*.js, *.jsx}` or something else to use as `loader.test`.
- * @param {object} [options]                    Optional advanced matching options.
+ * @param {object} [options]                    Rule options. See https://webpack.js.org/configuration/module/
  * @param {Function[]} configSetters            Array of functions as returned by webpack blocks.
  * @return {Function}
  */
@@ -20,6 +20,10 @@ function match (test, options, configSetters) {
   }
 
   assertConfigSetters(configSetters)
+
+  if (options.test) {
+    console.warn(`match(): Setting 'test' in options is not supported and will be overriden with a 'test' argument.`)
+  }
 
   options.test = createFileTypeMatcher(test)
 
@@ -36,14 +40,14 @@ const regexify = glob => globToRegex(glob, { extended: true })
 function createFileTypeMatcher (test) {
   if (typeof test === 'string') {
     return regexify(test)
-  } else if (Array.isArray(test) && test.every(item => typeof item === 'string')) {
-    return test.map(item => regexify(item))
-  } else {
-    return test
   }
+  if (Array.isArray(test) && test.every(item => typeof item === 'string')) {
+    return test.map(item => regexify(item))
+  }
+  return test
 }
 
-function deriveContextWithMatch (context, match) {
+function deriveContextWithMatch (context, options) {
   // Use an ES Proxy, so the returned context will include `match` and mutations
   // to it will also be applied to the original context. This is important,
   // since we have now got a global context object and local ones.
@@ -52,7 +56,7 @@ function deriveContextWithMatch (context, match) {
       return propName === 'match' ? true : (propName in target)
     },
     get (target, propName) {
-      return propName === 'match' ? match : target[propName]
+      return propName === 'match' ? options : target[propName]
     }
   })
 }

--- a/packages/core/lib/match.js
+++ b/packages/core/lib/match.js
@@ -27,7 +27,7 @@ function match (test, options, configSetters) {
   assertConfigSetters(configSetters)
 
   if (options.test) {
-    console.warn(`match(): Setting 'test' in options is not supported and will be overriden with a 'test' argument.`)
+    throw new Error(`match(): Setting 'test' in options is not supported and will be overriden with a 'test' argument.`)
   }
 
   const { inclusions, exclusions } = splitPatterns(toArray(test))
@@ -55,9 +55,8 @@ function normalizeMatchers (fileMatchTests) {
   return fileMatchTests.map(test => {
     if (typeof test === 'string') {
       return regexify(test)
-    } else {
-      return test
     }
+    return test
   })
 }
 


### PR DESCRIPTION
Currently it's not possible to pass [webpack rule options](https://webpack.js.org/configuration/module/) other than `exclude` and `include` to blocks. Also there is no way to remove default options from blocks (for example the `exclude` in the `babel` block).

This PR fixes both problems.