### PR TITLE
Increase cancel on "no output" timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
 cache:
   directories:
     - $HOME/.npm
+script:
+  - travis_wait 15 npm test   # Increase "no output received" timeout


### PR DESCRIPTION
Should fix Travis CI sometimes failing with "No output received in the last 10m" (esp. on node 6).