### PR TITLE
The new block API

### DIFF
--- a/packages/assets/lib/css.js
+++ b/packages/assets/lib/css.js
@@ -17,8 +17,8 @@ function css(options = {}) {
     loaders.unshift({ loader: 'style-loader', options: options.styleLoader || {} })
   }
 
-  return (context, util) =>
-    util.addLoader(
+  return context =>
+    context.addLoader(
       Object.assign(
         {
           test: /\.css$/,
@@ -56,8 +56,8 @@ function cssModules(options = {}) {
     loaders.unshift({ loader: 'style-loader', options: options.styleLoader || {} })
   }
 
-  return (context, util) =>
-    util.addLoader(
+  return context =>
+    context.addLoader(
       Object.assign(
         {
           test: /\.css$/,

--- a/packages/assets/lib/file.js
+++ b/packages/assets/lib/file.js
@@ -6,7 +6,7 @@ module.exports = file
  * @see https://github.com/webpack-contrib/file-loader
  */
 function file(options = {}) {
-  return (context, util) => {
+  return context => {
     if (!context.match) {
       throw new Error(
         `The file() block can only be used in combination with match(). ` +
@@ -14,7 +14,7 @@ function file(options = {}) {
       )
     }
 
-    return util.addLoader(
+    return context.addLoader(
       Object.assign(
         {
           use: [{ loader: 'file-loader', options }]

--- a/packages/assets/lib/url.js
+++ b/packages/assets/lib/url.js
@@ -6,7 +6,7 @@ module.exports = url
  * @see https://github.com/webpack-contrib/url-loader
  */
 function url(options = {}) {
-  return (context, util) => {
+  return context => {
     if (!context.match) {
       throw new Error(
         `The url() block can only be used in combination with match(). ` +
@@ -14,7 +14,7 @@ function url(options = {}) {
       )
     }
 
-    return util.addLoader(
+    return context.addLoader(
       Object.assign(
         {
           use: [{ loader: 'url-loader', options }]

--- a/packages/babel/index.js
+++ b/packages/babel/index.js
@@ -38,7 +38,7 @@ function babel(options = {}) {
   return Object.assign(setter, { post: postConfig })
 }
 
-function postConfig(context, util) {
+function postConfig(context) {
   const ruleConfig = Object.assign(
     {
       test: /\.(js|jsx)$/,
@@ -48,5 +48,5 @@ function postConfig(context, util) {
     context.match
   )
 
-  return util.addLoader(ruleConfig)
+  return context.addLoader(ruleConfig)
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove deprecated `fileType` API ([#260](https://github.com/andywer/webpack-blocks/issues/260))
 - Support for webpack 4 ([#261](https://github.com/andywer/webpack-blocks/pull/261))
+- The new block API ([#277](https://github.com/andywer/webpack-blocks/pull/277))
 
 ## 1.0.0
 

--- a/packages/core/lib/__tests__/createConfig.test.js
+++ b/packages/core/lib/__tests__/createConfig.test.js
@@ -1,7 +1,6 @@
 import test from 'ava'
 import sinon from 'sinon'
 import createConfig from '../createConfig'
-import blockHelpers from '../blockUtils'
 
 const defaultConfig = {
   distinct1: 'distinct1',
@@ -103,13 +102,12 @@ test('createConfig() invokes post hooks', t => {
   t.is(block2.post.callCount, 1)
   t.is(block3.post.callCount, 1)
 
-  t.is(block1.post.lastCall.args.length, 2)
+  t.is(block1.post.lastCall.args.length, 1)
   t.is(typeof block1.post.lastCall.args[0], 'object')
-  t.is(block1.post.lastCall.args[1], blockHelpers)
   const context = block1.post.lastCall.args[0]
 
-  t.deepEqual(block2.post.lastCall.args, [context, blockHelpers])
-  t.deepEqual(block3.post.lastCall.args, [context, blockHelpers])
+  t.deepEqual(block2.post.lastCall.args, [context])
+  t.deepEqual(block3.post.lastCall.args, [context])
 })
 
 test('createConfig() invokes hooks and setters in the right order', t => {

--- a/packages/core/lib/__tests__/env.test.js
+++ b/packages/core/lib/__tests__/env.test.js
@@ -7,7 +7,7 @@ process.env.NODE_ENV = 'testing'
 test('env() merges correctly', t => {
   const envBlock = env(process.env.NODE_ENV, [entryPoint1(), entryPoint2()])
 
-  t.deepEqual(envBlock(null, {})({}), {
+  t.deepEqual(envBlock({})({}), {
     entry: {
       foo: './src/foo',
       bar: './src/bar'
@@ -19,7 +19,7 @@ test('env() respects the NODE_ENV', t => {
   const envBlock = env('foo-bar', [entryPoint1(), entryPoint2()])
 
   const emptyConfig = { entry: {} }
-  t.deepEqual(envBlock(null, {})(emptyConfig), emptyConfig)
+  t.deepEqual(envBlock({})(emptyConfig), emptyConfig)
 })
 
 test('env() block passes complete config to child blocks', t => {

--- a/packages/core/lib/__tests__/when.test.js
+++ b/packages/core/lib/__tests__/when.test.js
@@ -5,7 +5,7 @@ import when from '../when'
 test('when() merges correctly', t => {
   const whenBlock = when(true, [entryPoint1(), entryPoint2()])
 
-  t.deepEqual(whenBlock(null, {})({}), {
+  t.deepEqual(whenBlock({})({}), {
     entry: {
       foo: './src/foo',
       bar: './src/bar'
@@ -17,7 +17,7 @@ test('when() respects the condition', t => {
   const whenBlock = when(false, [entryPoint1(), entryPoint2()])
 
   const emptyConfig = { entry: {} }
-  t.deepEqual(whenBlock(null, {})(emptyConfig), emptyConfig)
+  t.deepEqual(whenBlock({})(emptyConfig), emptyConfig)
 })
 
 test('when() block passes complete config to child blocks', t => {

--- a/packages/core/lib/configSetters.js
+++ b/packages/core/lib/configSetters.js
@@ -28,7 +28,6 @@ function assertConfigSetters(configSetters) {
 
 function invokeConfigSetters(configSetters, context, baseConfig) {
   return configSetters.reduce((config, setter) => {
-    const updateFunction = setter(context, blockUtils)
-    return updateFunction(config)
+    return setter(Object.assign(context, blockUtils))(config)
   }, baseConfig)
 }

--- a/packages/dev-server/index.js
+++ b/packages/dev-server/index.js
@@ -32,11 +32,11 @@ function devServer(options = {}, entry = []) {
   return Object.assign(setter, { post: postConfig })
 }
 
-function postConfig(context, util) {
+function postConfig(context) {
   const entryPointsToAdd = context.devServer.entry
 
   return prevConfig => {
-    return util.merge({
+    return context.merge({
       devServer: Object.assign(
         {
           hot: true,

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -11,8 +11,8 @@ module.exports = eslint
  * @return {Function}
  */
 function eslint(options = {}) {
-  return (context, util) =>
-    util.addLoader(
+  return context =>
+    context.addLoader(
       Object.assign(
         {
           test: /\.(js|jsx)$/,

--- a/packages/extract-text/__tests__/integration.test.js
+++ b/packages/extract-text/__tests__/integration.test.js
@@ -83,8 +83,8 @@ test('fails properly if nothing to extract can be found', t => {
 })
 
 function css() {
-  return (context, util) =>
-    util.addLoader(
+  return context =>
+    context.addLoader(
       Object.assign(
         {
           test: /\.css$/,
@@ -96,8 +96,8 @@ function css() {
 }
 
 function sass() {
-  return (context, util) =>
-    util.addLoader(
+  return context =>
+    context.addLoader(
       Object.assign(
         {
           test: /\.(sass|scss)$/,
@@ -109,8 +109,8 @@ function sass() {
 }
 
 function html() {
-  return (context, util) =>
-    util.addLoader(
+  return context =>
+    context.addLoader(
       Object.assign(
         {
           test: /\.html$/,

--- a/packages/extract-text/index.js
+++ b/packages/extract-text/index.js
@@ -15,7 +15,7 @@ module.exports = extractText
 function extractText(outputFilePattern = 'css/[name].[contenthash:8].css') {
   const plugin = new ExtractTextPlugin(outputFilePattern)
 
-  const postHook = (context, util) => prevConfig => {
+  const postHook = context => prevConfig => {
     let nextConfig = prevConfig
 
     // Only apply to loaders in the same `match()` group or css loaders if there is no `match()`
@@ -43,8 +43,8 @@ function extractText(outputFilePattern = 'css/[name].[contenthash:8].css') {
       nextConfig = removeLoaderRule(ruleToRemove)(nextConfig)
     }
 
-    nextConfig = util.addPlugin(plugin)(nextConfig)
-    nextConfig = util.addLoader(newLoaderDef)(nextConfig)
+    nextConfig = context.addPlugin(plugin)(nextConfig)
+    nextConfig = context.addLoader(newLoaderDef)(nextConfig)
 
     return nextConfig
   }

--- a/packages/postcss/index.js
+++ b/packages/postcss/index.js
@@ -25,7 +25,7 @@ function postcss(options = {}) {
   }
 
   const postcssOptions = _.omit(options, 'minimize')
-  return (context, util) => prevConfig => {
+  return context => prevConfig => {
     const ruleDef = Object.assign(
       {
         test: /\.css$/,
@@ -44,7 +44,7 @@ function postcss(options = {}) {
       context.match
     )
 
-    let nextConfig = util.addLoader(ruleDef)(prevConfig)
+    let nextConfig = context.addLoader(ruleDef)(prevConfig)
 
     return nextConfig
   }

--- a/packages/sass/index.js
+++ b/packages/sass/index.js
@@ -19,8 +19,8 @@ module.exports = sass
  */
 function sass(options = {}) {
   const sassOptions = _.omit(options, 'minimize')
-  return (context, util) =>
-    util.addLoader(
+  return context =>
+    context.addLoader(
       Object.assign(
         {
           test: /\.(sass|scss)$/,

--- a/packages/tslint/index.js
+++ b/packages/tslint/index.js
@@ -11,8 +11,8 @@ module.exports = tslint
  * @return {Function}
  */
 function tslint(options = {}) {
-  return (context, util) => prevConfig => {
-    let nextConfig = util.addLoader(
+  return context => prevConfig => {
+    let nextConfig = context.addLoader(
       Object.assign(
         {
           test: /\.(ts|tsx)$/,
@@ -23,7 +23,7 @@ function tslint(options = {}) {
       )
     )(prevConfig)
 
-    nextConfig = util.addPlugin(
+    nextConfig = context.addPlugin(
       new context.webpack.LoaderOptionsPlugin({
         options: {
           tslint: options

--- a/packages/typescript/index.js
+++ b/packages/typescript/index.js
@@ -13,8 +13,8 @@ module.exports = typescript
  * @return {Function}
  */
 function typescript(options = {}) {
-  return (context, util) =>
-    util.merge({
+  return context =>
+    context.merge({
       resolve: {
         extensions: ['.ts', '.tsx']
       },

--- a/packages/uglify/index.js
+++ b/packages/uglify/index.js
@@ -27,9 +27,9 @@ function uglify(options = {}) {
     options
   )
 
-  const postHook = (context, util) => {
+  const postHook = context => {
     const plugin = new UglifyJSPlugin(options)
-    return util.merge({
+    return context.merge({
       optimization: {
         minimizer: [plugin]
       }

--- a/packages/webpack/__tests__/entryPoint.test.js
+++ b/packages/webpack/__tests__/entryPoint.test.js
@@ -5,7 +5,7 @@ const { entryPoint } = require('../index')
 test('entryPoint() should normalize string to object entry', t => {
   const merge = sinon.spy(() => prevConfig => prevConfig)
 
-  entryPoint('./test.js')(null, { merge })({})
+  entryPoint('./test.js')({ merge })({})
 
   t.is(merge.callCount, 1)
   t.deepEqual(merge.lastCall.args, [
@@ -20,7 +20,7 @@ test('entryPoint() should normalize string to object entry', t => {
 test('entryPoint() should normalize string array to object entry', t => {
   const merge = sinon.spy(() => prevConfig => prevConfig)
 
-  entryPoint(['./test.js', './test2.js'])(null, { merge })({})
+  entryPoint(['./test.js', './test2.js'])({ merge })({})
 
   t.is(merge.callCount, 1)
   t.deepEqual(merge.lastCall.args, [
@@ -38,7 +38,7 @@ test("entryPoint() should normalize an entry object's values", t => {
   entryPoint({
     main: './app.js',
     test: ['./test.js']
-  })(null, { merge })({})
+  })({ merge })({})
 
   t.is(merge.callCount, 1)
   t.deepEqual(merge.lastCall.args, [

--- a/packages/webpack/index.js
+++ b/packages/webpack/index.js
@@ -46,8 +46,8 @@ function createConfig(configSetters) {
   return core.createConfig({ webpack, webpackVersion }, [createEmptyConfig].concat(configSetters))
 }
 
-function createEmptyConfig(context, util) {
-  return util.merge({
+function createEmptyConfig(context) {
+  return context.merge({
     module: {
       rules: []
     },
@@ -63,8 +63,8 @@ function createEmptyConfig(context, util) {
  * @see https://webpack.github.io/docs/configuration.html#entry
  */
 function entryPoint(entry) {
-  return (context, util) =>
-    util.merge({
+  return context =>
+    context.merge({
       entry: normalizeEntry(entry)
     })
 }
@@ -94,11 +94,11 @@ function normalizeEntry(entry) {
  * @see https://webpack.github.io/docs/configuration.html#plugins
  */
 function addPlugins(plugins) {
-  return (context, util) => util.merge({ plugins })
+  return context => context.merge({ plugins })
 }
 
 function customConfig(wpConfig) {
-  return (context, util) => util.merge(wpConfig)
+  return context => context.merge(wpConfig)
 }
 
 /**
@@ -108,8 +108,8 @@ function customConfig(wpConfig) {
  * @param {string} performanceBudget.hints              'warning' or 'error'
  */
 function performance(performanceBudget) {
-  return (context, util) =>
-    util.merge({
+  return context =>
+    context.merge({
       performance: performanceBudget
     })
 }
@@ -131,8 +131,8 @@ function resolve(config) {
  * @see https://webpack.github.io/docs/configuration.html#context
  */
 function setContext(contextPath) {
-  return (context, util) =>
-    util.merge({
+  return context =>
+    context.merge({
       context: path.resolve(contextPath)
     })
 }
@@ -141,7 +141,7 @@ function setContext(contextPath) {
  * @see https://webpack.github.io/docs/configuration.html#devtool
  */
 function setDevTool(devtool) {
-  return (context, util) => util.merge({ devtool })
+  return context => context.merge({ devtool })
 }
 
 /**
@@ -155,7 +155,7 @@ function setOutput(output) {
     }
   }
 
-  return (context, util) => util.merge({ output })
+  return context => context.merge({ output })
 }
 
 /**
@@ -168,9 +168,9 @@ function setOutput(output) {
  * @return {Function}
  */
 function sourceMaps(devtool = 'cheap-module-source-map') {
-  return (context, util) => {
+  return context => {
     context.sourceMaps = true
 
-    return util.merge({ devtool })
+    return context.merge({ devtool })
   }
 }

--- a/packages/webpack/lib/defineConstants.js
+++ b/packages/webpack/lib/defineConstants.js
@@ -20,11 +20,11 @@ function defineConstants(constants) {
   return Object.assign(setter, { post: addDefinePlugin })
 }
 
-function addDefinePlugin(context, util) {
+function addDefinePlugin(context) {
   const stringify = value => JSON.stringify(value, null, 2)
   const stringifiedConstants = mapProps(context.defineConstants, stringify)
 
-  return util.addPlugin(new context.webpack.DefinePlugin(stringifiedConstants))
+  return context.addPlugin(new context.webpack.DefinePlugin(stringifiedConstants))
 }
 
 function mapProps(object, valueMapper) {

--- a/packages/webpack/lib/setEnv.js
+++ b/packages/webpack/lib/setEnv.js
@@ -19,8 +19,8 @@ function setEnv(constants) {
   return Object.assign(setter, { post: addEnvironmentPlugin })
 }
 
-function addEnvironmentPlugin(context, util) {
-  return util.addPlugin(new context.webpack.EnvironmentPlugin(context.setEnv))
+function addEnvironmentPlugin(context) {
+  return context.addPlugin(new context.webpack.EnvironmentPlugin(context.setEnv))
 }
 
 function toObject(constants) {


### PR DESCRIPTION
I've proposed this API almost a year ago in #125 and I believe everyone is fine with it by now. TLDR:

```js
// Current:

function postConfig (context, util) {
  const ruleConfig = Object.assign({
    test: /\.(js|jsx)$/,
    exclude: /node_modules/,
    use: [
      { loader: 'babel-loader', options: context.babel }
    ]
  }, context.match)

  return util.addLoader(ruleConfig)
}

// This PR:

function postConfig (context) {
  const ruleConfig = Object.assign({
    test: /\.(js|jsx)$/,
    exclude: /node_modules/,
    use: [
      { loader: 'babel-loader', options: context.babel }
    ]
  }, context.match)

  return context.addLoader(ruleConfig)
}
```

The #259 is different because it merges `context` and utils into an object:

```js
function postConfig ({context, addLoader}) {
  // ...
}
```

cc @andywer @zcei @dmitmel @jvanbruegge 