### PR TITLE
Set NodeJS version for Travis strictly to 6.11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: node_js
 node_js:
   - 10
   - 8
-  - 6
+  - 6.11.5
 
 cache:
   yarn: true


### PR DESCRIPTION
[Webpack 4 has a requirement of a minimum Node version of 6.11.5](https://github.com/webpack/webpack/blob/86f56bf635659e9ab3d373f6e81dc66ee2391149/package.json#L86). Let's set it as well just to be sure...