### PR TITLE
Remove -rc tags to fix pesky peer deps warnings

### DIFF
--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -26,6 +26,6 @@
     "webpack": "^4.20.2"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -23,7 +23,7 @@
     "webpack": "^4.20.2"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc",
+    "@webpack-blocks/core": "^2.0.0",
     "babel-core": "^7.0.0"
   }
 }

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -19,6 +19,6 @@
     "webpack-dev-server": "^3.1.9"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -22,6 +22,6 @@
     "webpack": "^4.20.2"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }

--- a/packages/extract-text/package.json
+++ b/packages/extract-text/package.json
@@ -22,6 +22,6 @@
     "webpack": "^4.20.2"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -23,6 +23,6 @@
     "@webpack-blocks/core": "^2.0.0"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }

--- a/packages/sass/package.json
+++ b/packages/sass/package.json
@@ -27,6 +27,6 @@
     "webpack": "^4.20.2"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }

--- a/packages/tslint/package.json
+++ b/packages/tslint/package.json
@@ -20,6 +20,6 @@
     "typescript": "^3.1.2"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -19,6 +19,6 @@
     "typescript": "^3.1.2"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }

--- a/packages/uglify/package.json
+++ b/packages/uglify/package.json
@@ -25,6 +25,6 @@
     "webpack": "^4.20.2"
   },
   "peerDependencies": {
-    "@webpack-blocks/core": "^2.0.0-rc"
+    "@webpack-blocks/core": "^2.0.0"
   }
 }


### PR DESCRIPTION
Follow up on #305 - since the new version was published without a prerelease tag, this warning was reintroduced. Wish I had thought of this before I asked you to publish a new version!

Now that the version has no prerelease tags, this shouldn't need to be updated again unless another prerelease tag is added.