### PR TITLE
Change the peer dependencies for babel package

### DIFF
--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -24,6 +24,6 @@
   },
   "peerDependencies": {
     "@webpack-blocks/core": "^2.0.0",
-    "babel-core": "^7.0.0"
+    "@babel/core": "^7.0.0"
   }
 }


### PR DESCRIPTION
Changes the peer dependencies of @webpack-blocks/babel from `babel-core` to `@babel/core`